### PR TITLE
[mission5] 5단계 미션 구현 - 장동욱/개인

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mission-1",
       "version": "0.0.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.57.3",
         "lucide-react": "^0.542.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1407,6 +1408,80 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
+      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.3.tgz",
+      "integrity": "sha512-rg3DmmZQKEVCreXq6Am29hMVe1CzemXyIWVYyyua69y6XubfP+DzGfLxME/1uvdgwqdoaPbtjBDpEBhqxq1ZwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.1.tgz",
+      "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.57.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.3.tgz",
+      "integrity": "sha512-gROsjAJ9ckeBpsLyMwK9plaZjw1uhlGgKp2EEQRJryPmI0jpKoGc07rvZ7KF8nk7H8UCwvUeYl68Fiw6M13tNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.5",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.3",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "^2.10.4"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1466,6 +1541,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.1.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
@@ -1484,6 +1574,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -3878,6 +3977,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -3897,6 +4002,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
@@ -4052,6 +4163,22 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4171,6 +4298,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.57.3",
     "lucide-react": "^0.542.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,6 @@
-// src/App.jsx
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "./context/AuthContext.jsx";
 
-// 레이아웃 & 페이지
 import MainLayout from "./layouts/MainLayout.jsx";
 import Home from "./pages/Home.jsx";
 import MovieDetail from "./pages/MovieDetail.jsx";
@@ -15,26 +13,16 @@ import Genres from "./pages/Genres.jsx";
 export default function App() {
   return (
     <BrowserRouter>
-      {/* ✅ 전역 인증 컨텍스트로 전체 앱 감싸기 */}
-      <AuthProvider>
+      <AuthProvider> {/* ✅ 전역 감싸기 */}
         <Routes>
           <Route element={<MainLayout />}>
-            {/* 홈 */}
             <Route index element={<Home />} />
-
-            {/* 상세 */}
             <Route path="details/:id" element={<MovieDetail />} />
-
-            {/* 인증 */}
             <Route path="login" element={<Login />} />
             <Route path="signup" element={<Signup />} />
-
-            {/* 메뉴 페이지들 */}
             <Route path="trending" element={<Trending />} />
             <Route path="top" element={<Top />} />
             <Route path="genres" element={<Genres />} />
-
-            {/* 없는 경로 → 홈으로 */}
             <Route path="*" element={<Home />} />
           </Route>
         </Routes>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,12 @@
+// src/App.jsx
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "./context/AuthContext.jsx";
+
+// 공용 레이아웃
+import MainLayout from "./layouts/MainLayout.jsx";
+
+// 페이지
 import RootPage from "./pages/RootPage.jsx";
-import MainLayout from "./layouts/MainLayout.jsx";   
 import MovieDetail from "./pages/MovieDetail.jsx";
 import Login from "./pages/Login.jsx";
 import Signup from "./pages/Signup.jsx";
@@ -9,19 +14,60 @@ import Trending from "./pages/Trending.jsx";
 import Top from "./pages/Top.jsx";
 import Genres from "./pages/Genres.jsx";
 
+// 마이페이지 관련
+import MyPage from "./pages/MyPage.jsx";
+import MyWishlist from "./pages/MyWishlist.jsx";
+import MyBookmark from "./pages/MyBookmark.jsx";
+
+// 보호 라우트
+import RequireAuth from "./routes/RequireAuth.jsx";
+
 export default function App() {
   return (
     <BrowserRouter>
       <AuthProvider>
         <Routes>
           <Route element={<MainLayout />}>
-            <Route index element={<RootPage />} />  
+            {/* 홈 */}
+            <Route index element={<RootPage />} />
+
+            {/* 상세 */}
             <Route path="details/:id" element={<MovieDetail />} />
+
+            {/* 공개 페이지 */}
             <Route path="login" element={<Login />} />
             <Route path="signup" element={<Signup />} />
             <Route path="trending" element={<Trending />} />
             <Route path="top" element={<Top />} />
             <Route path="genres" element={<Genres />} />
+
+            {/* 보호 라우트: 로그인 필요 */}
+            <Route
+              path="mypage"
+              element={
+                <RequireAuth>
+                  <MyPage />
+                </RequireAuth>
+              }
+            />
+            <Route
+              path="mypage/wishlist"
+              element={
+                <RequireAuth>
+                  <MyWishlist />
+                </RequireAuth>
+              }
+            />
+            <Route
+              path="mypage/bookmark"
+              element={
+                <RequireAuth>
+                  <MyBookmark />
+                </RequireAuth>
+              }
+            />
+
+            {/* Fallback */}
             <Route path="*" element={<RootPage />} />
           </Route>
         </Routes>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,7 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "./context/AuthContext.jsx";
-
-import MainLayout from "./layouts/MainLayout.jsx";
-import Home from "./pages/Home.jsx";
+import RootPage from "./pages/RootPage.jsx";
+import MainLayout from "./layouts/MainLayout.jsx";   
 import MovieDetail from "./pages/MovieDetail.jsx";
 import Login from "./pages/Login.jsx";
 import Signup from "./pages/Signup.jsx";
@@ -13,17 +12,17 @@ import Genres from "./pages/Genres.jsx";
 export default function App() {
   return (
     <BrowserRouter>
-      <AuthProvider> {/* ✅ 전역 감싸기 */}
+      <AuthProvider>
         <Routes>
           <Route element={<MainLayout />}>
-            <Route index element={<Home />} />
+            <Route index element={<RootPage />} />  
             <Route path="details/:id" element={<MovieDetail />} />
             <Route path="login" element={<Login />} />
             <Route path="signup" element={<Signup />} />
             <Route path="trending" element={<Trending />} />
             <Route path="top" element={<Top />} />
             <Route path="genres" element={<Genres />} />
-            <Route path="*" element={<Home />} />
+            <Route path="*" element={<RootPage />} />
           </Route>
         </Routes>
       </AuthProvider>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,19 +1,44 @@
+// src/App.jsx
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-import MainLayout from "./layouts/MainLayout";
-import Home from "./pages/Home";
-import MovieDetail from "./pages/MovieDetail"; // 상세 페이지 컴포넌트
+import { AuthProvider } from "./context/AuthContext.jsx";
+
+// 레이아웃 & 페이지
+import MainLayout from "./layouts/MainLayout.jsx";
+import Home from "./pages/Home.jsx";
+import MovieDetail from "./pages/MovieDetail.jsx";
+import Login from "./pages/Login.jsx";
+import Signup from "./pages/Signup.jsx";
+import Trending from "./pages/Trending.jsx";
+import Top from "./pages/Top.jsx";
+import Genres from "./pages/Genres.jsx";
 
 export default function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route element={<MainLayout />}>
-          {/* "/" → Home */}
-          <Route index element={<Home />} />
-          {/* "/details/:id" → MovieDetail */}
-          <Route path="details/:id" element={<MovieDetail />} />
-        </Route>
-      </Routes>
+      {/* ✅ 전역 인증 컨텍스트로 전체 앱 감싸기 */}
+      <AuthProvider>
+        <Routes>
+          <Route element={<MainLayout />}>
+            {/* 홈 */}
+            <Route index element={<Home />} />
+
+            {/* 상세 */}
+            <Route path="details/:id" element={<MovieDetail />} />
+
+            {/* 인증 */}
+            <Route path="login" element={<Login />} />
+            <Route path="signup" element={<Signup />} />
+
+            {/* 메뉴 페이지들 */}
+            <Route path="trending" element={<Trending />} />
+            <Route path="top" element={<Top />} />
+            <Route path="genres" element={<Genres />} />
+
+            {/* 없는 경로 → 홈으로 */}
+            <Route path="*" element={<Home />} />
+          </Route>
+        </Routes>
+      </AuthProvider>
     </BrowserRouter>
   );
 }

--- a/src/components/FormInput.jsx
+++ b/src/components/FormInput.jsx
@@ -1,0 +1,26 @@
+// src/components/FormInput.jsx
+export default function FormInput({
+  label,
+  type = "text",
+  value,
+  onChange,
+  placeholder = "",
+  error = "",
+}) {
+  return (
+    <label className="block mb-3">
+      <span className="block mb-1 text-sm text-white/80">{label}</span>
+      <input
+        type={type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className={`w-full rounded-lg border px-3 py-2 bg-white/90 text-gray-900 outline-none
+        ${error ? "border-red-400" : "border-transparent"} focus:ring-2 focus:ring-indigo-300`}
+      />
+      {error ? (
+        <span className="mt-1 text-xs text-red-400 block">{error}</span>
+      ) : null}
+    </label>
+  );
+}

--- a/src/components/HeroCarousel.jsx
+++ b/src/components/HeroCarousel.jsx
@@ -1,0 +1,45 @@
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Navigation, Autoplay } from "swiper/modules";
+import "swiper/css";
+import "swiper/css/navigation";
+import { Link } from "react-router-dom";
+import { tmdbImage } from "../api/tmdb.js";
+
+export default function HeroCarousel({ items = [] }) {
+  return (
+    <div className="relative rounded-2xl overflow-hidden border border-white/10 bg-black/30">
+      <Swiper
+        modules={[Navigation, Autoplay]}
+        navigation
+        autoplay={{ delay: 4000, disableOnInteraction: false }}
+        loop={items.length > 1}
+        slidesPerView={1}
+        className="[&_.swiper-button-prev]:!text-white [&_.swiper-button-next]:!text-white"
+      >
+        {items.map((m) => (
+          <SwiperSlide key={m.id}>
+            <Link to={`/details/${m.id}`} className="block">
+              <div
+                className="w-full"
+                style={{
+                  /* 16:6 정도의 와이드 */
+                  aspectRatio: "16 / 6",
+                  backgroundImage: `url(${tmdbImage(m.backdrop_path || m.poster_path, "original")})`,
+                  backgroundSize: "cover",
+                  backgroundPosition: "center",
+                }}
+              />
+              <div className="absolute inset-0 bg-gradient-to-t from-black/65 via-black/20 to-transparent" />
+              <div className="absolute left-8 bottom-8 max-w-[50%]">
+                <h3 className="text-3xl md:text-4xl font-extrabold drop-shadow">{m.title}</h3>
+                {m.tagline && (
+                  <p className="mt-2 text-white/85 line-clamp-2">{m.tagline}</p>
+                )}
+              </div>
+            </Link>
+          </SwiperSlide>
+        ))}
+      </Swiper>
+    </div>
+  );
+}

--- a/src/components/MediaCard.jsx
+++ b/src/components/MediaCard.jsx
@@ -1,8 +1,25 @@
-// src/components/MediaCard.jsx
 import { Link } from "react-router-dom";
 import { tmdbImage } from "../api/tmdb.js";
+import { has as wishHas, toggle as wishToggle } from "../lib/wishlist.js";
+import { useEffect, useState } from "react";
 
 function MediaCard({ item, badge, to = `/details/${item.id}` }) {
+  const [liked, setLiked] = useState(wishHas(item.id));
+
+  // 외부에서 변경되었을 때도 반영
+  useEffect(() => {
+    const off = () => setLiked(wishHas(item.id));
+    window.addEventListener("wishlist:change", off);
+    return () => window.removeEventListener("wishlist:change", off);
+  }, [item.id]);
+
+  const onHeart = (e) => {
+    e.preventDefault(); // 카드 링크 이동 막기
+    e.stopPropagation();
+    const now = wishToggle(item);
+    setLiked(now);
+  };
+
   return (
     <Link
       to={to}
@@ -29,10 +46,23 @@ function MediaCard({ item, badge, to = `/details/${item.id}` }) {
         <p className="text-sm font-medium text-white truncate">{item.title}</p>
       </div>
 
+      {/* ♥ 버튼 */}
+      <button
+        type="button"
+        onClick={onHeart}
+        aria-label={liked ? "찜 해제" : "찜하기"}
+        className="absolute right-2 bottom-2 z-10 rounded-full px-2.5 py-1 text-sm
+                   bg-black/50 hover:bg-black/70 border border-white/10"
+      >
+        <span className={liked ? "text-red-400" : "text-white/80"}>
+          {liked ? "♥" : "♡"}
+        </span>
+      </button>
+
       {/* gradient hover */}
-      <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
+      <div className="absolute inset-0 transition-opacity opacity-0 pointer-events-none bg-gradient-to-t from-black/40 via-transparent to-transparent group-hover:opacity-100" />
     </Link>
   );
 }
 
-export default MediaCard; // ✅ 반드시 default export
+export default MediaCard;

--- a/src/components/MediaCard.jsx
+++ b/src/components/MediaCard.jsx
@@ -1,0 +1,38 @@
+// src/components/MediaCard.jsx
+import { Link } from "react-router-dom";
+import { tmdbImage } from "../api/tmdb.js";
+
+function MediaCard({ item, badge, to = `/details/${item.id}` }) {
+  return (
+    <Link
+      to={to}
+      className="block group relative rounded-2xl overflow-hidden bg-[#121833] border border-white/5"
+    >
+      {/* badge */}
+      {badge && (
+        <span className="absolute left-2 top-2 z-10 rounded-md px-2 py-0.5 text-[11px] font-semibold
+                         bg-fuchsia-600/90 text-white shadow">
+          {badge}
+        </span>
+      )}
+
+      {/* poster */}
+      <img
+        src={tmdbImage(item.poster_path, "w500")}
+        alt={item.title}
+        className="w-full h-[280px] object-cover group-hover:scale-[1.02] transition-transform duration-300"
+        loading="lazy"
+      />
+
+      {/* title */}
+      <div className="px-2.5 py-2">
+        <p className="text-sm font-medium text-white truncate">{item.title}</p>
+      </div>
+
+      {/* gradient hover */}
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
+    </Link>
+  );
+}
+
+export default MediaCard; // ✅ 반드시 default export

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Link, NavLink, useSearchParams, useNavigate } from "react-router-dom";
+import { Link, NavLink, useSearchParams, useNavigate, useLocation } from "react-router-dom";
 import useDebounce from "../hooks/useDebounce.js";
 import { useAuth } from "../context/AuthContext.jsx";
 
@@ -11,6 +11,7 @@ export default function NavBar() {
   const dq = useDebounce(q, 500);
 
   const nav = useNavigate();
+  const loc = useLocation(); // ✅ 검색 시 홈으로 보내기 위해 사용
   const { user, logout } = useAuth();
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -26,6 +27,7 @@ export default function NavBar() {
     return () => document.removeEventListener("pointerdown", handleDocPointerDown);
   }, [menuOpen]);
 
+  // 🔎 디바운스된 검색어를 URL 파라미터로 반영 + 검색어가 있으면 홈으로 이동
   useEffect(() => {
     const next = new URLSearchParams(params);
     if (dq.trim()) {
@@ -36,6 +38,11 @@ export default function NavBar() {
       next.delete("page");
     }
     setParams(next, { replace: false });
+
+    // ✅ 다른 페이지에서 입력해도 홈으로 이동하여 검색 결과 노출
+    if (dq.trim() && loc.pathname !== "/") {
+      nav(`/?${next.toString()}`, { replace: false });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dq]);
 
@@ -49,10 +56,12 @@ export default function NavBar() {
     // z-index를 더 높여 위에 깔리게
     <header className="sticky top-0 z-50 w-full border-b border-white/10 bg-[#0B1020]/70 backdrop-blur-md">
       <nav className="mx-auto flex h-14 max-w-7xl items-center gap-4 px-4">
+        {/* 로고 */}
         <Link to="/" className="text-xl font-extrabold tracking-tight">
           <span className="text-[#3366FF]">OZ</span>Wave
         </Link>
 
+        {/* 메뉴 */}
         <div className="ml-6 hidden gap-6 md:flex">
           {[
             { to: "/", label: "홈" },
@@ -76,6 +85,7 @@ export default function NavBar() {
 
         {/* 오른쪽: 검색 + 계정 */}
         <div className="ml-auto flex items-center gap-3">
+          {/* 🔎 검색 인풋 (버튼 없음, 자동 검색) */}
           <input
             value={q}
             onChange={(e) => setQ(e.target.value)}
@@ -103,7 +113,7 @@ export default function NavBar() {
           ) : (
             <div className="relative" ref={menuRef}>
               <button
-                type="button"                       // ✅ 명시
+                type="button"
                 onClick={() => setMenuOpen((v) => !v)}
                 className="w-9 h-9 rounded-full overflow-hidden bg-white/10 focus:ring-2 focus:ring-indigo-300"
                 title={user.userName || user.email}
@@ -118,7 +128,7 @@ export default function NavBar() {
               {menuOpen && (
                 <div
                   className="absolute right-0 mt-2 w-44 rounded-xl bg-[#121833] shadow-xl
-                             border border-white/10 p-1 z-[9999]"   // ✅ 매우 높은 z-index
+                             border border-white/10 p-1 z-[9999]"
                   role="menu"
                   aria-label="account menu"
                 >

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,3 +1,4 @@
+// src/components/NavBar.jsx
 import { useEffect, useRef, useState } from "react";
 import { Link, NavLink, useSearchParams, useNavigate, useLocation } from "react-router-dom";
 import useDebounce from "../hooks/useDebounce.js";
@@ -11,23 +12,24 @@ export default function NavBar() {
   const dq = useDebounce(q, 500);
 
   const nav = useNavigate();
-  const loc = useLocation(); // ✅ 검색 시 홈으로 보내기 위해 사용
+  const loc = useLocation();
   const { user, logout } = useAuth();
   const [menuOpen, setMenuOpen] = useState(false);
 
-  // 드롭다운 외부 클릭 시 닫기
   const menuRef = useRef(null);
+
+  // 바깥 클릭 시 드롭다운 닫기
   useEffect(() => {
-    function handleDocPointerDown(e) {
+    function onDocDown(e) {
       if (menuOpen && menuRef.current && !menuRef.current.contains(e.target)) {
         setMenuOpen(false);
       }
     }
-    document.addEventListener("pointerdown", handleDocPointerDown);
-    return () => document.removeEventListener("pointerdown", handleDocPointerDown);
+    document.addEventListener("pointerdown", onDocDown);
+    return () => document.removeEventListener("pointerdown", onDocDown);
   }, [menuOpen]);
 
-  // 🔎 디바운스된 검색어를 URL 파라미터로 반영 + 검색어가 있으면 홈으로 이동
+  // 검색어 ↔ URL 동기화
   useEffect(() => {
     const next = new URLSearchParams(params);
     if (dq.trim()) {
@@ -38,8 +40,6 @@ export default function NavBar() {
       next.delete("page");
     }
     setParams(next, { replace: false });
-
-    // ✅ 다른 페이지에서 입력해도 홈으로 이동하여 검색 결과 노출
     if (dq.trim() && loc.pathname !== "/") {
       nav(`/?${next.toString()}`, { replace: false });
     }
@@ -47,22 +47,21 @@ export default function NavBar() {
   }, [dq]);
 
   const onLogout = async () => {
-    await logout(); // Context에서 세션/캐시 제거 + setUser(null)
+    await logout();
     setMenuOpen(false);
     nav("/", { replace: true });
   };
 
   return (
-    // z-index를 더 높여 위에 깔리게
     <header className="sticky top-0 z-50 w-full border-b border-white/10 bg-[#0B1020]/70 backdrop-blur-md">
-      <nav className="mx-auto flex h-14 max-w-7xl items-center gap-4 px-4">
+      <nav className="flex items-center gap-4 px-4 mx-auto h-14 max-w-7xl">
         {/* 로고 */}
         <Link to="/" className="text-xl font-extrabold tracking-tight">
           <span className="text-[#3366FF]">OZ</span>Wave
         </Link>
 
-        {/* 메뉴 */}
-        <div className="ml-6 hidden gap-6 md:flex">
+        {/* 상단 메뉴 */}
+        <div className="hidden gap-6 ml-6 md:flex">
           {[
             { to: "/", label: "홈" },
             { to: "/trending", label: "실시간" },
@@ -83,9 +82,8 @@ export default function NavBar() {
           ))}
         </div>
 
-        {/* 오른쪽: 검색 + 계정 */}
-        <div className="ml-auto flex items-center gap-3">
-          {/* 🔎 검색 인풋 (버튼 없음, 자동 검색) */}
+        {/* 검색 + 계정 */}
+        <div className="flex items-center gap-3 ml-auto">
           <input
             value={q}
             onChange={(e) => setQ(e.target.value)}
@@ -112,33 +110,48 @@ export default function NavBar() {
             </div>
           ) : (
             <div className="relative" ref={menuRef}>
+              {/* 아바타 버튼: 드롭다운 토글 */}
               <button
                 type="button"
                 onClick={() => setMenuOpen((v) => !v)}
-                className="w-9 h-9 rounded-full overflow-hidden bg-white/10 focus:ring-2 focus:ring-indigo-300"
+                className="overflow-hidden rounded-full w-9 h-9 focus:ring-2 focus:ring-indigo-300"
                 title={user.userName || user.email}
               >
                 <img
                   src={user.profileImageUrl}
                   alt="avatar"
-                  className="w-full h-full object-cover pointer-events-none"
+                  className="object-cover w-full h-full pointer-events-none"
                 />
               </button>
 
+              {/* 드롭다운 */}
               {menuOpen && (
                 <div
-                  className="absolute right-0 mt-2 w-44 rounded-xl bg-[#121833] shadow-xl
-                             border border-white/10 p-1 z-[9999]"
+                  className="absolute right-0 mt-2 w-44 rounded-xl bg-[#121833] shadow-xl border border-white/10 p-1 z-[9999]"
                   role="menu"
-                  aria-label="account menu"
                 >
                   <div className="px-3 py-2 text-xs text-white/60">
                     {user.userName || user.email}
                   </div>
+
+                  {/* ✅ 마이페이지: onMouseDown에서 내비게이션 → 언마운트 경합 방지 */}
+                  <Link
+                    to="/mypage"
+                    onMouseDown={(e) => {
+                      e.preventDefault();      // Link 기본 내비게이션 취소
+                      e.stopPropagation();     // 바깥 pointerdown에 닫히기 전에
+                      nav("/mypage");          // 먼저 이동
+                      setMenuOpen(false);      // 그 다음 닫기
+                    }}
+                    className="block w-full px-3 py-2 text-sm text-left text-white rounded-lg hover:bg-white/10"
+                  >
+                    마이페이지
+                  </Link>
+
                   <button
                     type="button"
                     onClick={onLogout}
-                    className="w-full text-left px-3 py-2 rounded-lg text-sm text-red-400 hover:bg-white/10"
+                    className="w-full px-3 py-2 text-sm text-left text-red-400 rounded-lg hover:bg-white/10"
                   >
                     로그아웃
                   </button>

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,14 +1,33 @@
 // src/components/NavBar.jsx
 import { useEffect, useState } from "react";
-import { Link, NavLink, useSearchParams } from "react-router-dom";
+import { Link, NavLink, useSearchParams, useNavigate } from "react-router-dom";
 import useDebounce from "../hooks/useDebounce.js";
+import { useAuth } from "../context/AuthContext.jsx";
 
 const BRAND_BLUE = "#3366FF";
 
-export default function NavBar() {   // ✅ default export
+function avatarFallback(nameOrEmail) {
+  return (
+    "https://ui-avatars.com/api/?" +
+    new URLSearchParams({
+      name: nameOrEmail || "user",
+      background: "3366FF",
+      color: "FFFFFF",
+      bold: "true",
+      size: "96",
+      format: "png",
+    }).toString()
+  );
+}
+
+export default function NavBar() {
   const [params, setParams] = useSearchParams();
   const [q, setQ] = useState(params.get("q") || "");
   const dq = useDebounce(q, 500);
+
+  const { user, logout } = useAuth();
+  const nav = useNavigate();
+  const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => {
     const next = new URLSearchParams(params);
@@ -22,6 +41,12 @@ export default function NavBar() {   // ✅ default export
     setParams(next, { replace: false });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dq]);
+
+  const onLogout = async () => {
+    await logout();
+    setMenuOpen(false);
+    nav("/", { replace: true });
+  };
 
   return (
     <header className="sticky top-0 z-40 w-full border-b border-white/10 bg-[#0B1020]/70 backdrop-blur-md">
@@ -44,24 +69,73 @@ export default function NavBar() {   // ✅ default export
                 "text-sm transition-colors hover:text-white/90 " +
                 (isActive ? "font-semibold" : "text-white/70")
               }
-              style={({ isActive }) => ({
-                color: isActive ? BRAND_BLUE : undefined,
-              })}
+              style={({ isActive }) => ({ color: isActive ? BRAND_BLUE : undefined })}
             >
               {i.label}
             </NavLink>
           ))}
         </div>
 
-        <div className="ml-auto flex items-center">
+        {/* 오른쪽: 검색 + 계정 */}
+        <div className="ml-auto flex items-center gap-3">
           <input
             value={q}
             onChange={(e) => setQ(e.target.value)}
-            placeholder="제목으로 검색 (예: Dune)"
-            className="w-64 md:w-80 rounded-full px-4 py-2 text-sm outline-none
+            placeholder="제목으로 검색"
+            className="w-52 md:w-80 rounded-full px-4 py-2 text-sm
                        bg-white/10 text-white placeholder-white/50
-                       focus:ring-2 focus:ring-[rgba(51,102,255,.45)]"
+                       border border-white/10
+                       outline-none focus:outline-none focus:ring-0 focus:border-white/20"
           />
+
+          {!user ? (
+            <div className="flex items-center gap-2 min-w-[180px] justify-end">
+              <Link
+                to="/login"
+                className="px-3 py-1.5 rounded-lg bg-white/10 text-white hover:bg-white/20 text-sm"
+              >
+                로그인
+              </Link>
+              <Link
+                to="/signup"
+                className="px-3 py-1.5 rounded-lg bg-[#3366FF] text-white text-sm"
+              >
+                회원가입
+              </Link>
+            </div>
+          ) : (
+            <div className="relative">
+              <button
+                onClick={() => setMenuOpen((v) => !v)}
+                // 파란 포커스 링 제거
+                className="w-9 h-9 rounded-full overflow-hidden bg-white/10"
+                title={user.userName || user.email}
+              >
+                <img
+                  src={user.profileImageUrl || avatarFallback(user.userName || user.email)}
+                  alt="avatar"
+                  className="w-full h-full object-cover"
+                  referrerPolicy="no-referrer"
+                  onError={(e) => {
+                    e.currentTarget.src = avatarFallback(user.userName || user.email);
+                  }}
+                />
+              </button>
+              {menuOpen && (
+                <div
+                  onMouseLeave={() => setMenuOpen(false)}
+                  className="absolute right-0 mt-2 w-40 rounded-xl bg-[#121833] shadow-lg border border-white/10 p-1"
+                >
+                  <button
+                    onClick={onLogout}
+                    className="w-full text-left px-3 py-2 rounded-lg text-sm text-red-400 hover:bg-white/10"
+                  >
+                    로그아웃
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </nav>
     </header>

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,33 +1,30 @@
-// src/components/NavBar.jsx
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, NavLink, useSearchParams, useNavigate } from "react-router-dom";
 import useDebounce from "../hooks/useDebounce.js";
 import { useAuth } from "../context/AuthContext.jsx";
 
 const BRAND_BLUE = "#3366FF";
 
-function avatarFallback(nameOrEmail) {
-  return (
-    "https://ui-avatars.com/api/?" +
-    new URLSearchParams({
-      name: nameOrEmail || "user",
-      background: "3366FF",
-      color: "FFFFFF",
-      bold: "true",
-      size: "96",
-      format: "png",
-    }).toString()
-  );
-}
-
 export default function NavBar() {
   const [params, setParams] = useSearchParams();
   const [q, setQ] = useState(params.get("q") || "");
   const dq = useDebounce(q, 500);
 
-  const { user, logout } = useAuth();
   const nav = useNavigate();
+  const { user, logout } = useAuth();
   const [menuOpen, setMenuOpen] = useState(false);
+
+  // 드롭다운 외부 클릭 시 닫기
+  const menuRef = useRef(null);
+  useEffect(() => {
+    function handleDocPointerDown(e) {
+      if (menuOpen && menuRef.current && !menuRef.current.contains(e.target)) {
+        setMenuOpen(false);
+      }
+    }
+    document.addEventListener("pointerdown", handleDocPointerDown);
+    return () => document.removeEventListener("pointerdown", handleDocPointerDown);
+  }, [menuOpen]);
 
   useEffect(() => {
     const next = new URLSearchParams(params);
@@ -43,13 +40,14 @@ export default function NavBar() {
   }, [dq]);
 
   const onLogout = async () => {
-    await logout();
+    await logout(); // Context에서 세션/캐시 제거 + setUser(null)
     setMenuOpen(false);
     nav("/", { replace: true });
   };
 
   return (
-    <header className="sticky top-0 z-40 w-full border-b border-white/10 bg-[#0B1020]/70 backdrop-blur-md">
+    // z-index를 더 높여 위에 깔리게
+    <header className="sticky top-0 z-50 w-full border-b border-white/10 bg-[#0B1020]/70 backdrop-blur-md">
       <nav className="mx-auto flex h-14 max-w-7xl items-center gap-4 px-4">
         <Link to="/" className="text-xl font-extrabold tracking-tight">
           <span className="text-[#3366FF]">OZ</span>Wave
@@ -82,14 +80,13 @@ export default function NavBar() {
             value={q}
             onChange={(e) => setQ(e.target.value)}
             placeholder="제목으로 검색"
-            className="w-52 md:w-80 rounded-full px-4 py-2 text-sm
+            className="w-48 md:w-72 rounded-full px-4 py-2 text-sm outline-none
                        bg-white/10 text-white placeholder-white/50
-                       border border-white/10
-                       outline-none focus:outline-none focus:ring-0 focus:border-white/20"
+                       focus:ring-2 focus:ring-[rgba(51,102,255,.45)]"
           />
 
           {!user ? (
-            <div className="flex items-center gap-2 min-w-[180px] justify-end">
+            <div className="flex items-center gap-2">
               <Link
                 to="/login"
                 className="px-3 py-1.5 rounded-lg bg-white/10 text-white hover:bg-white/20 text-sm"
@@ -104,29 +101,32 @@ export default function NavBar() {
               </Link>
             </div>
           ) : (
-            <div className="relative">
+            <div className="relative" ref={menuRef}>
               <button
+                type="button"                       // ✅ 명시
                 onClick={() => setMenuOpen((v) => !v)}
-                // 파란 포커스 링 제거
-                className="w-9 h-9 rounded-full overflow-hidden bg-white/10"
+                className="w-9 h-9 rounded-full overflow-hidden bg-white/10 focus:ring-2 focus:ring-indigo-300"
                 title={user.userName || user.email}
               >
                 <img
-                  src={user.profileImageUrl || avatarFallback(user.userName || user.email)}
+                  src={user.profileImageUrl}
                   alt="avatar"
-                  className="w-full h-full object-cover"
-                  referrerPolicy="no-referrer"
-                  onError={(e) => {
-                    e.currentTarget.src = avatarFallback(user.userName || user.email);
-                  }}
+                  className="w-full h-full object-cover pointer-events-none"
                 />
               </button>
+
               {menuOpen && (
                 <div
-                  onMouseLeave={() => setMenuOpen(false)}
-                  className="absolute right-0 mt-2 w-40 rounded-xl bg-[#121833] shadow-lg border border-white/10 p-1"
+                  className="absolute right-0 mt-2 w-44 rounded-xl bg-[#121833] shadow-xl
+                             border border-white/10 p-1 z-[9999]"   // ✅ 매우 높은 z-index
+                  role="menu"
+                  aria-label="account menu"
                 >
+                  <div className="px-3 py-2 text-xs text-white/60">
+                    {user.userName || user.email}
+                  </div>
                   <button
+                    type="button"
                     onClick={onLogout}
                     className="w-full text-left px-3 py-2 rounded-lg text-sm text-red-400 hover:bg-white/10"
                   >

--- a/src/components/SectionHeader.jsx
+++ b/src/components/SectionHeader.jsx
@@ -1,0 +1,15 @@
+function SectionHeader({ title, moreTo = "#", className = "" }) {
+  return (
+    <div className={`flex items-end justify-between mb-4 ${className}`}>
+      <h2 className="text-[22px] font-bold tracking-tight text-white">{title}</h2>
+      <a
+        href={moreTo}
+        className="text-sm text-white/70 hover:text-white flex items-center gap-1"
+      >
+        더보기 <span aria-hidden>›</span>
+      </a>
+    </div>
+  );
+}
+
+export default SectionHeader; 

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,0 +1,62 @@
+// src/context/AuthContext.jsx
+import { createContext, useContext, useEffect, useState } from "react";
+import { supabase } from "../lib/supabase";
+import { getUserInfo } from "../hooks/useSupabaseAuth.js"; // 우리가 만든 표준화 함수 사용
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    (async () => {
+      try {
+        // 1) 현재 세션 확인
+        const { data: { session } } = await supabase.auth.getSession();
+
+        if (mounted) {
+          if (session?.user) {
+            // 표준화 + localStorage 저장
+            const u = await getUserInfo();
+            setUser(u);
+          } else {
+            // 2) 세션이 없으면 localStorage 값이라도 복구
+            const raw = localStorage.getItem("userInfo");
+            setUser(raw ? JSON.parse(raw) : null);
+          }
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+
+    // 3) 로그인/로그아웃/토큰변경 구독
+    const { data: sub } = supabase.auth.onAuthStateChange(async (_event, session) => {
+      if (!mounted) return;
+      if (session?.user) {
+        const u = await getUserInfo();
+        setUser(u);
+      } else {
+        setUser(null);
+        localStorage.removeItem("userInfo");
+      }
+    });
+
+    return () => {
+      mounted = false;
+      sub.subscription?.unsubscribe?.();
+    };
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, setUser, loading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);
+export default AuthContext;

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,62 +1,85 @@
-// src/context/AuthContext.jsx
 import { createContext, useContext, useEffect, useState } from "react";
 import { supabase } from "../lib/supabase";
-import { getUserInfo } from "../hooks/useSupabaseAuth.js"; // 우리가 만든 표준화 함수 사용
 
 const AuthContext = createContext(null);
 
+function getCachedUser() {
+  try {
+    let sbKey = null;
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k && k.startsWith("sb-") && k.endsWith("-auth-token")) { sbKey = k; break; }
+    }
+    if (!sbKey) return null;
+    const parsed = JSON.parse(localStorage.getItem(sbKey) || "{}");
+    const cur = parsed.currentSession || parsed.session || parsed;
+    const u = cur?.user;
+    if (!u?.id) return null;
+    return {
+      id: u.id,
+      email: u.email || "",
+      userName: u.user_metadata?.name || u.user_metadata?.user_name || "",
+      profileImageUrl:
+        u.user_metadata?.avatar_url ||
+        `https://ui-avatars.com/api/?name=${encodeURIComponent(u.user_metadata?.name || u.email || "user")}&background=3366FF&color=FFFFFF&bold=true&size=96&format=png`,
+    };
+  } catch { return null; }
+}
+
 export function AuthProvider({ children }) {
-  const [user, setUser] = useState(null);
-  const [loading, setLoading] = useState(true);
+  const cached = getCachedUser();
+  const [user, setUser] = useState(cached);
+  const [loading, setLoading] = useState(!cached);
+
+  // ✅ 반드시 Context에서 logout 함수 제공
+  const logout = async () => {
+    try {
+      await supabase.auth.signOut();
+    } catch (e) {
+      console.error("signOut error:", e);
+    } finally {
+      localStorage.removeItem("userInfo");
+      setUser(null);
+    }
+  };
 
   useEffect(() => {
-    let mounted = true;
-
+    let alive = true;
     (async () => {
       try {
-        // 1) 현재 세션 확인
         const { data: { session } } = await supabase.auth.getSession();
-
-        if (mounted) {
-          if (session?.user) {
-            // 표준화 + localStorage 저장
-            const u = await getUserInfo();
-            setUser(u);
-          } else {
-            // 2) 세션이 없으면 localStorage 값이라도 복구
-            const raw = localStorage.getItem("userInfo");
-            setUser(raw ? JSON.parse(raw) : null);
-          }
-        }
+        if (!alive) return;
+        if (session?.user) {
+          setUser(getCachedUser() || {
+            id: session.user.id,
+            email: session.user.email || "",
+            userName: session.user.user_metadata?.name || session.user.user_metadata?.user_name || "",
+            profileImageUrl:
+              session.user.user_metadata?.avatar_url ||
+              `https://ui-avatars.com/api/?name=${encodeURIComponent(session.user.user_metadata?.name || session.user.email || "user")}&background=3366FF&color=FFFFFF&bold=true&size=96&format=png`,
+          });
+        } else setUser(null);
       } finally {
-        if (mounted) setLoading(false);
+        if (alive) setLoading(false);
       }
     })();
 
-    // 3) 로그인/로그아웃/토큰변경 구독
-    const { data: sub } = supabase.auth.onAuthStateChange(async (_event, session) => {
-      if (!mounted) return;
-      if (session?.user) {
-        const u = await getUserInfo();
-        setUser(u);
-      } else {
+    const { data: sub } = supabase.auth.onAuthStateChange((_evt, session) => {
+      if (!alive) return;
+      if (session?.user) setUser(getCachedUser());
+      else {
         setUser(null);
         localStorage.removeItem("userInfo");
       }
     });
-
-    return () => {
-      mounted = false;
-      sub.subscription?.unsubscribe?.();
-    };
+    return () => { alive = false; sub.subscription?.unsubscribe?.(); };
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, setUser, loading }}>
+    <AuthContext.Provider value={{ user, setUser, loading, logout }}>
       {children}
     </AuthContext.Provider>
   );
 }
 
 export const useAuth = () => useContext(AuthContext);
-export default AuthContext;

--- a/src/hooks/useSupabaseAuth.js
+++ b/src/hooks/useSupabaseAuth.js
@@ -1,0 +1,103 @@
+import { supabase } from "../lib/supabase";
+
+/** 로컬스토리지 키 */
+const LS_KEY = "userInfo";
+
+/** 공통: 유저 객체 표준화 */
+function normUser(sessionUser, profileImageUrl) {
+  if (!sessionUser) return null;
+  const { id, email, user_metadata } = sessionUser;
+  return {
+    id,
+    email: email ?? "",
+    userName: user_metadata?.name || user_metadata?.user_name || "",
+    profileImageUrl:
+      profileImageUrl ||
+      user_metadata?.avatar_url ||
+      "https://api.dicebear.com/9.x/initials/svg?seed=" +
+        encodeURIComponent(user_metadata?.name || email || "user"),
+  };
+}
+
+/** 현재 세션 기반 유저정보 가져오기 + LocalStorage 저장 */
+export async function getUserInfo() {
+  const { data: { session } } = await supabase.auth.getSession();
+  const user = normUser(session?.user);
+  if (user) localStorage.setItem(LS_KEY, JSON.stringify(user));
+  return user;
+}
+
+/** 이메일/비번 회원가입 */
+export async function signup({ email, password, userName }) {
+  const { data, error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: { data: { name: userName } },
+  });
+
+  if (error) {
+    return { error: { status: error.status || 400, message: error.message } };
+  }
+
+  const user = normUser(data.user);
+  if (user) localStorage.setItem(LS_KEY, JSON.stringify(user));
+  return { user };
+}
+
+/** 이메일/비번 로그인 */
+export async function login({ email, password }) {
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+
+  if (error) {
+    return { error: { status: error.status || 400, message: error.message } };
+  }
+
+  const user = normUser(data.user);
+  if (user) localStorage.setItem(LS_KEY, JSON.stringify(user));
+  return { user };
+}
+
+/** 로그아웃 */
+export async function logout() {
+  await supabase.auth.signOut();
+  localStorage.removeItem(LS_KEY);
+  return { ok: true };
+}
+
+/** Google 소셜 로그인 */
+export async function loginWithGoogle() {
+  const { error } = await supabase.auth.signInWithOAuth({
+    provider: "google",
+  });
+  if (error) {
+    return { error: { status: error.status || 400, message: error.message } };
+  }
+  return { ok: true };
+}
+
+/** Kakao 소셜 로그인 (Supabase Auth에 제공자 활성화 필요) */
+export async function loginWithKakao() {
+  const { error } = await supabase.auth.signInWithOAuth({
+    provider: "kakao",
+  });
+  if (error) {
+    return { error: { status: error.status || 400, message: error.message } };
+  }
+  return { ok: true };
+}
+
+/** 훅 래퍼 (요구사항 이름) */
+export default function useSupabaseAuth() {
+  return {
+    login,
+    signup,
+    logout,
+    getUserInfo,
+    loginWithGoogle,
+    loginWithKakao,
+  };
+}
+

--- a/src/hooks/useThrottle.js
+++ b/src/hooks/useThrottle.js
@@ -1,0 +1,19 @@
+// src/hooks/useThrottle.js
+import { useRef, useCallback } from "react";
+
+/**
+ * 함수 실행을 지정한 delay(ms) 단위로 제한하는 훅
+ * @param {Function} fn 실행할 함수
+ * @param {number} delay 지연 시간(ms), 기본값 500ms
+ */
+export default function useThrottle(fn, delay = 500) {
+  const last = useRef(0);
+
+  return useCallback((...args) => {
+    const now = Date.now();
+    if (now - last.current >= delay) {
+      last.current = now;
+      fn(...args);
+    }
+  }, [fn, delay]);
+}

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -1,4 +1,3 @@
-// src/layouts/MainLayout.jsx
 import { Outlet, useLocation } from "react-router-dom";
 import NavBar from "../components/NavBar.jsx";
 
@@ -7,7 +6,6 @@ export default function MainLayout() {
 
   return (
     <div className="min-h-screen text-white" style={{ backgroundColor: "#0B0F1E" }}>
-      {/* 상단 배경 그라디언트 */}
       <div
         className="pointer-events-none absolute inset-0 -z-10"
         aria-hidden
@@ -18,22 +16,13 @@ export default function MainLayout() {
           `,
         }}
       />
-
       <NavBar />
-
       <main className="w-full">
         <Outlet />
       </main>
-
-      {/* 상세 페이지일 때 하단 그라디언트 살짝 */}
       {loc.pathname.startsWith("/details/") && (
-        <div
-          aria-hidden
-          className="h-20 w-full"
-          style={{
-            background:
-              "linear-gradient(180deg, transparent 0%, rgba(51,102,255,.18) 100%)",
-          }}
+        <div aria-hidden className="h-20 w-full"
+          style={{ background: "linear-gradient(180deg, transparent 0%, rgba(51,102,255,.18) 100%)" }}
         />
       )}
     </div>

--- a/src/lib/bookmark.js
+++ b/src/lib/bookmark.js
@@ -1,0 +1,65 @@
+// src/lib/bookmark.js
+const LS_KEY = "bookmark_v1";
+
+function read() {
+  try {
+    return JSON.parse(localStorage.getItem(LS_KEY) || "[]");
+  } catch {
+    return [];
+  }
+}
+function write(arr) {
+  localStorage.setItem(LS_KEY, JSON.stringify(arr));
+  window.dispatchEvent(new CustomEvent("bookmark:change"));
+}
+
+/** 전체 북마크 목록 */
+export function list() {
+  return read();
+}
+
+/** 특정 영화가 북마크 되어있는지 */
+export function has(id) {
+  return read().some((m) => m.id === id);
+}
+
+/** 북마크 추가 */
+export function add(movie) {
+  const arr = read();
+  if (!arr.some((m) => m.id === movie.id)) {
+    arr.push({
+      id: movie.id,
+      title: movie.title || movie.name || "",
+      poster_path: movie.poster_path || "",
+      vote_average: movie.vote_average ?? 0,
+    });
+    write(arr);
+  }
+}
+
+/** 북마크 제거 */
+export function remove(id) {
+  write(read().filter((m) => m.id !== id));
+}
+
+/** 토글: true=북마크됨, false=해제됨 */
+export function toggle(movie) {
+  if (has(movie.id)) {
+    remove(movie.id);
+    return false;
+  } else {
+    add(movie);
+    return true;
+  }
+}
+
+/** 변경 구독 (언마운트 시 리턴 호출) */
+export function subscribe(handler) {
+  const onChange = () => handler(list());
+  window.addEventListener("bookmark:change", onChange);
+  return () => window.removeEventListener("bookmark:change", onChange);
+}
+
+/* ✅ 기본 내보내기 (default) */
+const api = { list, has, add, remove, toggle, subscribe };
+export default api;

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,11 +1,22 @@
-// src/lib/supabase.js
 import { createClient } from "@supabase/supabase-js";
 
-const url = import.meta.env.VITE_SUPABASE_PROJECT_URL;
-const key = import.meta.env.VITE_SUPABASE_API_KEY;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_PROJECT_URL;
+const supabaseKey = import.meta.env.VITE_SUPABASE_API_KEY;
 
-if (!url || !key) {
-  console.warn("[supabase] VITE_SUPABASE_PROJECT_URL / VITE_SUPABASE_API_KEY가 필요합니다.");
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error("Missing env: VITE_SUPABASE_PROJECT_URL / VITE_SUPABASE_API_KEY");
 }
 
-export const supabase = createClient(url, key); // ✅ named export
+export const supabase = createClient(supabaseUrl, supabaseKey, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+    detectSessionInUrl: true,
+    storage: localStorage,
+    storageKey: "ozwave-auth", // ← 위 AUTH_STORAGE_KEY와 값만 동일하면 됨
+  },
+});
+
+if (typeof window !== "undefined" && import.meta.env.DEV) {
+  window.supabase = supabase; // 디버깅 편의
+}

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -1,0 +1,11 @@
+// src/lib/supabase.js
+import { createClient } from "@supabase/supabase-js";
+
+const url = import.meta.env.VITE_SUPABASE_PROJECT_URL;
+const key = import.meta.env.VITE_SUPABASE_API_KEY;
+
+if (!url || !key) {
+  console.warn("[supabase] VITE_SUPABASE_PROJECT_URL / VITE_SUPABASE_API_KEY가 필요합니다.");
+}
+
+export const supabase = createClient(url, key); // ✅ named export

--- a/src/lib/wishlist.js
+++ b/src/lib/wishlist.js
@@ -1,0 +1,63 @@
+// src/lib/wishlist.js
+const LS_KEY = "wishlist_v1";
+
+// 내부: 저장/로드
+function read() {
+  try {
+    return JSON.parse(localStorage.getItem(LS_KEY) || "[]");
+  } catch {
+    return [];
+  }
+}
+function write(arr) {
+  localStorage.setItem(LS_KEY, JSON.stringify(arr));
+  // 구독자 알림
+  window.dispatchEvent(new CustomEvent("wishlist:change"));
+}
+
+/** 전체 목록 */
+export function list() {
+  return read();
+}
+
+/** 해당 id가 찜 상태인지 */
+export function has(id) {
+  return read().some((m) => m.id === id);
+}
+
+/** 추가(중복방지) */
+export function add(movie) {
+  const arr = read();
+  if (!arr.some((m) => m.id === movie.id)) {
+    arr.push({
+      id: movie.id,
+      title: movie.title || movie.name || "",
+      poster_path: movie.poster_path || "",
+      vote_average: movie.vote_average ?? 0,
+    });
+    write(arr);
+  }
+}
+
+/** 제거 */
+export function remove(id) {
+  write(read().filter((m) => m.id !== id));
+}
+
+/** 토글 (찜/해제) → true=찜됨, false=해제됨 */
+export function toggle(movie) {
+  if (has(movie.id)) {
+    remove(movie.id);
+    return false;
+  } else {
+    add(movie);
+    return true;
+  }
+}
+
+/** 상태 변경 구독 (언마운트 시 리턴 함수 호출) */
+export function subscribe(handler) {
+  const onChange = () => handler(list());
+  window.addEventListener("wishlist:change", onChange);
+  return () => window.removeEventListener("wishlist:change", onChange);
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,21 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
 import "./index.css";
-
-import MainLayout from "./layouts/MainLayout.jsx";
-import Home from "./pages/Home.jsx";
-import MovieDetail from "./pages/MovieDetail.jsx";
+import App from "./App.jsx";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <Routes>
-        <Route element={<MainLayout />}>
-          <Route index element={<Home />} />
-          <Route path="details/:id" element={<MovieDetail />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+    <App />
   </React.StrictMode>
 );

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App.jsx";
+import { AuthProvider } from "./context/AuthContext.jsx";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/src/pages/AuthCallback.jsx
+++ b/src/pages/AuthCallback.jsx
@@ -1,0 +1,65 @@
+// src/pages/AuthCallback.jsx
+import { useEffect, useState } from "react";
+import { useNavigate, useLocation, Link } from "react-router-dom";
+import { supabase } from "../lib/supabase";
+
+export default function AuthCallback() {
+  const nav = useNavigate();
+  const loc = useLocation();
+  const [msg, setMsg] = useState("초기화 중…");
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        // A. 이미 세션이 있으면 바로 홈으로 (detectSessionInUrl가 먼저 처리했을 때)
+        const { data: s } = await supabase.auth.getSession();
+        if (s?.session) {
+          if (alive) nav("/", { replace: true });
+          return;
+        }
+
+        // B. PKCE 코드로 교환
+        const sp = new URLSearchParams(loc.search);
+        const code = sp.get("code");
+        if (code) {
+          const { error } = await supabase.auth.exchangeCodeForSession({
+            authCode: code,
+          });
+          if (error) throw error;
+          if (alive) nav("/", { replace: true });
+          return;
+        }
+
+        // C. implicit(flowType 미사용)로 해시 토큰이 올 때
+        const hash = new URLSearchParams(window.location.hash.slice(1));
+        const accessToken = hash.get("access_token");
+        if (accessToken) {
+          // detectSessionInUrl=true라면 supabase가 자체 처리/정리함
+          await supabase.auth.getSession();
+          if (alive) nav("/", { replace: true });
+          return;
+        }
+
+        // D. 여기까지 오면 정말로 코드가 없는 케이스(설정 점검 필요)
+        setMsg("유효한 인증 코드가 없어 로그인 페이지로 이동합니다.");
+        setTimeout(() => nav("/login", { replace: true }), 800);
+      } catch (e) {
+        console.error(e);
+        if (alive) setMsg(`로그인 처리 실패: ${e?.message || "알 수 없는 오류"}`);
+      }
+    })();
+    return () => { alive = false; };
+  }, [loc.search, nav]);
+
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center text-white">
+      <div className="rounded-xl border border-white/10 bg-[#0E1324] px-6 py-8 shadow-2xl">
+        <p className="text-sm text-white/80">{msg}</p>
+        <p className="mt-4 text-xs text-white/50">
+          문제가 계속되면 <Link to="/login" className="underline">로그인</Link>으로 돌아가세요.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Genres.jsx
+++ b/src/pages/Genres.jsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from "react";
+import { discoverMovies, fetchGenres } from "../api/tmdb.js";
+import SectionHeader from "../components/SectionHeader.jsx";
+import MediaCard from "../components/MediaCard.jsx";
+
+function Genres() {
+  const [genres, setGenres] = useState([]);
+  const [active, setActive] = useState(""); // TMDB genre id string
+  const [items, setItems] = useState([]);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+
+  // 장르 목록
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      const r = await fetchGenres();
+      if (alive) setGenres(r.genres || []);
+    })();
+    return () => { alive = false; };
+  }, []);
+
+  // 선택 장르/페이지에 맞는 영화
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      setLoading(true);
+      try {
+        const r = await discoverMovies({
+          page,
+          with_genres: active,
+          sort_by: "popularity.desc",
+        });
+        if (alive) setItems((r.results || []).filter((m) => !m.adult));
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => { alive = false; };
+  }, [active, page]);
+
+  return (
+    <div className="mx-auto max-w-[1400px] px-4 md:px-6 py-8 space-y-6">
+      <SectionHeader title="장르로 찾기" />
+
+      {/* 장르 칩 */}
+      <div className="flex flex-wrap gap-2">
+        <button
+          onClick={() => { setActive(""); setPage(1); }}
+          className={
+            "px-3 py-1.5 rounded-lg text-sm " +
+            (active === "" ? "bg-[#3366FF] text-white" : "bg-white/10 text-white/80 hover:bg-white/15")
+          }
+        >
+          전체
+        </button>
+        {genres.map((g) => (
+          <button
+            key={g.id}
+            onClick={() => { setActive(String(g.id)); setPage(1); }}
+            className={
+              "px-3 py-1.5 rounded-lg text-sm " +
+              (active === String(g.id)
+                ? "bg-[#3366FF] text-white"
+                : "bg-white/10 text-white/80 hover:bg-white/15")
+            }
+          >
+            {g.name}
+          </button>
+        ))}
+      </div>
+
+      {/* 결과 */}
+      {loading ? (
+        <p className="text-white/70">불러오는 중…</p>
+      ) : items.length ? (
+        <>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-7">
+            {items.map((m) => (
+              <MediaCard key={m.id} item={m} />
+            ))}
+          </div>
+
+          <div className="flex items-center justify-center gap-3 pt-6">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              className="px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/15 disabled:opacity-50"
+              disabled={page === 1}
+            >
+              이전
+            </button>
+            <span className="text-white/70 text-sm">페이지 {page}</span>
+            <button
+              onClick={() => setPage((p) => p + 1)}
+              className="px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/15"
+            >
+              다음
+            </button>
+          </div>
+        </>
+      ) : (
+        <p className="text-white/60">해당 장르에 결과가 없습니다.</p>
+      )}
+    </div>
+  );
+}
+
+export default Genres;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,12 @@
-import { useEffect, useState, useMemo } from "react";
-import { fetchPopularMovies, fetchTrendingMovies, fetchTopRatedMovies } from "../api/tmdb.js";
+// src/pages/Home.jsx
+import { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  fetchPopularMovies,
+  fetchTrendingMovies,
+  fetchTopRatedMovies,
+  searchMovies,
+} from "../api/tmdb.js";
 import SectionHeader from "../components/SectionHeader.jsx";
 import MediaCard from "../components/MediaCard.jsx";
 import HeroCarousel from "../components/HeroCarousel.jsx";
@@ -7,12 +14,21 @@ import { Swiper, SwiperSlide } from "swiper/react";
 import { Navigation } from "swiper/modules";
 import "swiper/css";
 import "swiper/css/navigation";
+import { includesChoseong, isChoseongQuery } from "../utils/korean.js";
+import useThrottle from "../hooks/useThrottle.js";
 
 export default function Home() {
+  // ===== 공통 상태 =====
   const [popular, setPopular] = useState([]);
   const [trending, setTrending] = useState([]);
   const [top, setTop] = useState([]);
   const [loading, setLoading] = useState(true);
+
+  // 🔎 URL ?q= 읽어서 검색 모드 전환
+  const [params] = useSearchParams();
+  const q = (params.get("q") || "").trim();
+  const [searching, setSearching] = useState(false);
+  const [results, setResults] = useState([]);
 
   const canShowHero = trending.length > 0;
 
@@ -23,6 +39,7 @@ export default function Home() {
     return 2;
   }, []);
 
+  // 홈 기본 데이터
   useEffect(() => {
     let alive = true;
     (async () => {
@@ -34,92 +51,229 @@ export default function Home() {
           fetchTopRatedMovies(1),
         ]);
         if (!alive) return;
-        setPopular((p.results || []).filter((m) => !m.adult));
-        setTrending((t.results || []).filter((m) => !m.adult));
-        setTop((r.results || []).filter((m) => !m.adult));
-      } catch (e) {
-        console.error(e);
+        const clean = (arr) => (arr || []).filter((m) => !m.adult);
+        setPopular(clean(p.results));
+        setTrending(clean(t.results));
+        setTop(clean(r.results));
       } finally {
         if (alive) setLoading(false);
       }
     })();
-    return () => (alive = false);
+    return () => { alive = false; };
   }, []);
 
+  // 🔎 검색 모드: TMDB 검색 + (초성만이면) 로컬 초성 매칭 보강
+  useEffect(() => {
+    let alive = true;
+    if (!q) {
+      setResults([]);
+      setSearching(false);
+      return;
+    }
+    (async () => {
+      setSearching(true);
+      try {
+        const list = [];
+
+        // 1) TMDB API 검색
+        try {
+          const api = await searchMovies(q, 1);
+          if (api?.results) list.push(...api.results.filter((m) => !m.adult));
+        } catch (err) {
+          console.warn("TMDB search failed:", err);
+        }
+
+        // 2) 초성 쿼리면 로컬 풀에서 초성 매칭
+        if (isChoseongQuery(q)) {
+          const pool = [...popular, ...trending, ...top];
+          const extra = pool.filter((m) => includesChoseong(m.title || "", q));
+          list.push(...extra);
+        }
+
+        // 3) id 기준 중복 제거
+        const uniq = Array.from(new Map(list.map((m) => [m.id, m])).values());
+        if (alive) setResults(uniq);
+      } finally {
+        if (alive) setSearching(false);
+      }
+    })();
+    return () => { alive = false; };
+  }, [q, popular, trending, top]);
+
+  // ===== 메인 무한 스크롤 (인기 영화 기반) =====
+  const [infPage, setInfPage] = useState(0);         // 마지막으로 로드 완료한 페이지
+  const [infItems, setInfItems] = useState([]);      // 누적 리스트
+  const [infLoading, setInfLoading] = useState(false);
+  const [infDone, setInfDone] = useState(false);
+  const guardRef = useRef(null);
+  const fetchingRef = useRef(false);
+
+  const loadMore = useCallback(async (nextPage) => {
+    if (fetchingRef.current || infDone) return;
+    fetchingRef.current = true;
+    setInfLoading(true);
+    try {
+      const r = await fetchPopularMovies(nextPage);
+      const rows = (r.results || []).filter((m) => !m.adult);
+      setInfItems((prev) => prev.concat(rows));
+      setInfPage(nextPage);
+      if (!rows.length || nextPage >= (r.total_pages || 500)) {
+        setInfDone(true);
+      }
+    } catch (e) {
+      // 실패 시엔 다음 기회에 재시도 가능하게만 처리
+      console.warn("infinite load error:", e);
+    } finally {
+      setInfLoading(false);
+      fetchingRef.current = false;
+    }
+  }, [infDone]);
+
+  // 초기 1페이지
+  useEffect(() => {
+    if (q) return; // 검색 모드일 땐 무한스크롤 섹션 숨김
+    loadMore(1);
+  }, [q, loadMore]);
+
+  // sentinel 관찰
+  const throttledLoad = useThrottle((p) => loadMore(p), 700);
+
+  useEffect(() => {
+    if (q || infDone) return;
+    const el = guardRef.current;
+    if (!el) return;
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.some((e) => e.isIntersecting);
+        if (visible) throttledLoad(infPage + 1);
+      },
+      { root: null, rootMargin: "800px 0px", threshold: 0 }
+    );
+
+    io.observe(el);
+    return () => io.disconnect();
+  }, [q, infPage, infDone, throttledLoad]);
+
+  // 뷰포트 채우기(스크롤 생성 안 될 때 자동 추가 로드)
+  useEffect(() => {
+    if (q || infDone || infLoading) return;
+    const notScrollable =
+      document.documentElement.scrollHeight <= window.innerHeight + 100;
+    if (notScrollable && infPage >= 1) throttledLoad(infPage + 1);
+  }, [q, infItems, infPage, infLoading, infDone, throttledLoad]);
+
+  // ===== 렌더 =====
   return (
     <div className="min-h-screen" style={{ backgroundColor: "#181a1c" }}>
       <div className="mx-auto max-w-[1400px] px-4 md:px-6 py-6 space-y-10">
-        {/* 상단 히어로 */}
-        {canShowHero && <HeroCarousel items={trending.slice(0, 8)} />}
 
-        {/* 에디터 추천작(=인기) */}
-        <section>
-          <SectionHeader title="믿고 보는 에디터 추천작" moreTo="#" />
-          <Swiper
-            modules={[Navigation]}
-            navigation
-            spaceBetween={16}
-            slidesPerView={2}
-            breakpoints={{
-              640: { slidesPerView: 4 },
-              1024: { slidesPerView: 6 },
-              1280: { slidesPerView: 7 },
-            }}
-            className="[&_.swiper-button-prev]:!text-white [&_.swiper-button-next]:!text-white"
-          >
-            {popular.map((m, i) => (
-              <SwiperSlide key={m.id}>
-                <MediaCard item={m} badge={i < 3 ? "NEW" : undefined} />
-              </SwiperSlide>
-            ))}
-          </Swiper>
-        </section>
+        {/* 🔎 검색 모드 섹션 */}
+        {q ? (
+          <section className="pb-12">
+            <SectionHeader title="검색 결과" moreTo="#" />
+            {searching ? (
+              <p className="text-white/70">검색 중…</p>
+            ) : results.length ? (
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-7">
+                {results.map((m) => (
+                  <MediaCard key={m.id} item={m} />
+                ))}
+              </div>
+            ) : (
+              <p className="text-white/60">"{q}"에 대한 결과가 없습니다.</p>
+            )}
+          </section>
+        ) : (
+          // 기본 홈 섹션
+          <>
+            {canShowHero && <HeroCarousel items={trending.slice(0, 8)} />}
 
-        {/* 실시간 인기 콘텐츠(=트렌딩) */}
-        <section>
-          <SectionHeader title="실시간 인기 콘텐츠" moreTo="#" />
-          <Swiper
-            modules={[Navigation]}
-            navigation
-            spaceBetween={16}
-            slidesPerView={2}
-            breakpoints={{
-              640: { slidesPerView: 4 },
-              1024: { slidesPerView: 6 },
-              1280: { slidesPerView: 7 },
-            }}
-            className="[&_.swiper-button-prev]:!text-white [&_.swiper-button-next]:!text-white"
-          >
-            {trending.map((m) => (
-              <SwiperSlide key={m.id}>
-                <MediaCard item={m} badge="Quick VOD" />
-              </SwiperSlide>
-            ))}
-          </Swiper>
-        </section>
+            <section>
+              <SectionHeader title="믿고 보는 에디터 추천작" moreTo="#" />
+              <Swiper
+                modules={[Navigation]}
+                navigation
+                spaceBetween={16}
+                slidesPerView={2}
+                breakpoints={{
+                  640: { slidesPerView: 4 },
+                  1024: { slidesPerView: 6 },
+                  1280: { slidesPerView: 7 },
+                }}
+                className="[&_.swiper-button-prev]:!text-white [&_.swiper-button-next]:!text-white"
+              >
+                {popular.map((m, i) => (
+                  <SwiperSlide key={m.id}>
+                    <MediaCard item={m} badge={i < 3 ? "NEW" : undefined} />
+                  </SwiperSlide>
+                ))}
+              </Swiper>
+            </section>
 
-        {/* 평점 좋은 작품 */}
-        <section className="pb-12">
-          <SectionHeader title="고평점 작품" moreTo="#" />
-          <Swiper
-            modules={[Navigation]}
-            navigation
-            spaceBetween={16}
-            slidesPerView={2}
-            breakpoints={{
-              640: { slidesPerView: 4 },
-              1024: { slidesPerView: 6 },
-              1280: { slidesPerView: 7 },
-            }}
-            className="[&_.swiper-button-prev]:!text-white [&_.swiper-button-next]:!text-white"
-          >
-            {top.map((m) => (
-              <SwiperSlide key={m.id}>
-                <MediaCard item={m} />
-              </SwiperSlide>
-            ))}
-          </Swiper>
-        </section>
+            <section>
+              <SectionHeader title="실시간 인기 콘텐츠" moreTo="#" />
+              <Swiper
+                modules={[Navigation]}
+                navigation
+                spaceBetween={16}
+                slidesPerView={2}
+                breakpoints={{
+                  640: { slidesPerView: 4 },
+                  1024: { slidesPerView: 6 },
+                  1280: { slidesPerView: 7 },
+                }}
+                className="[&_.swiper-button-prev]:!text-white [&_.swiper-button-next]:!text-white"
+              >
+                {trending.map((m) => (
+                  <SwiperSlide key={m.id}>
+                    <MediaCard item={m} badge="Quick VOD" />
+                  </SwiperSlide>
+                ))}
+              </Swiper>
+            </section>
+
+            <section>
+              <SectionHeader title="고평점 작품" moreTo="#" />
+              <Swiper
+                modules={[Navigation]}
+                navigation
+                spaceBetween={16}
+                slidesPerView={2}
+                breakpoints={{
+                  640: { slidesPerView: 4 },
+                  1024: { slidesPerView: 6 },
+                  1280: { slidesPerView: 7 },
+                }}
+                className="[&_.swiper-button-prev]:!text-white [&_.swiper-button-next]:!text-white"
+              >
+                {top.map((m) => (
+                  <SwiperSlide key={m.id}>
+                    <MediaCard item={m} />
+                  </SwiperSlide>
+                ))}
+              </Swiper>
+            </section>
+
+            {/* ✅ 메인 무한 스크롤 섹션 */}
+            <section className="pb-12">
+              <SectionHeader title="전체 인기 작품 (무한 스크롤)" />
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-7">
+                {infItems.map((m) => (
+                  <MediaCard key={`${m.id}-${m.title}`} item={m} />
+                ))}
+              </div>
+
+              <div className="py-6 text-center text-white/70">
+                {infLoading && <p>불러오는 중…</p>}
+                {infDone && <p>모든 데이터를 불러왔습니다.</p>}
+              </div>
+
+              {/* 관찰용 센티넬 */}
+              <div ref={guardRef} className="h-4" />
+            </section>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,109 +1,117 @@
-import { useEffect, useState } from "react";
-import { useNavigate, useLocation, Link } from "react-router-dom";
-import { login } from "../hooks/useSupabaseAuth";
-import { useAuth } from "../context/AuthContext";
+// src/pages/Login.jsx
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { login, loginWithGoogle, loginWithKakao } from "../hooks/useSupabaseAuth";
+
+// 공통 토큰 (회원가입 화면과 동일 톤)
+const CARD =
+  "mx-auto w-[min(92vw,560px)] rounded-2xl bg-[#0E1324] shadow-2xl border border-white/10 p-8 md:p-10";
+const TITLE = "text-3xl md:text-4xl font-extrabold mb-8";
+const LABEL = "block mb-2 text-sm text-white/70";
+const INPUT =
+  "w-full h-12 rounded-lg bg-white/10 text-white placeholder-white/50 px-4 outline-none focus:ring-2 focus:ring-[rgba(51,102,255,.45)]";
+const PRIMARY_BTN =
+  "w-full h-12 rounded-lg bg-[#3867FF] hover:brightness-110 text-white font-semibold transition";
+const SECONDARY_BTN =
+  "w-full h-12 rounded-lg bg-white/10 hover:bg-white/15 text-white font-semibold transition";
+const KAKAO_BTN =
+  "w-full h-12 rounded-lg bg-[#FEE500] text-[#191600] font-semibold transition hover:brightness-95";
 
 export default function Login() {
   const nav = useNavigate();
-  const loc = useLocation();
-  const { user, setUser, loading } = useAuth();
+  const [form, setForm] = useState({ email: "", password: "" });
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState("");
 
-  const [email, setEmail] = useState("");
-  const [pw, setPw] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [msg, setMsg] = useState(loc.state?.msg || "");
-  const [error, setError] = useState("");
-
-  // 로그인되어 있으면 이 페이지에 머물 이유가 없음
-  useEffect(() => {
-    if (!loading && user) nav("/", { replace: true });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loading, user]);
+  const onChange = (e) => setForm({ ...form, [e.target.name]: e.target.value });
 
   const onSubmit = async (e) => {
     e.preventDefault();
-    if (submitting) return;
+    if (busy) return;
+    setBusy(true);
+    setErr("");
 
-    setError("");
-    setMsg("");
-    setSubmitting(true);
+    const { error } = await login(form);
+    setBusy(false);
 
-    try {
-      const { user: u, error: err } = await login({ email, password: pw });
-
-      if (err) {
-        const pretty =
-          err.message === "Invalid login credentials"
-            ? "이메일/비밀번호가 올바르지 않거나 이메일 인증이 완료되지 않았습니다."
-            : err.message || "로그인 실패";
-        setError(pretty);
-        return;
-      }
-
-      setUser(u);                 // ✅ 전역 상태 갱신
-      nav("/", { replace: true }); // ✅ 즉시 이동
-    } catch (ex) {
-      setError(ex?.message || "알 수 없는 오류가 발생했습니다.");
-    } finally {
-      setSubmitting(false);        // ✅ 절대 멈추지 않게
+    if (error) {
+      setErr(error.message || "로그인 실패");
+      return;
     }
+    nav("/", { replace: true });
   };
 
-  // 초기 세션 복구 중이면 살짝 로딩만
-  if (loading) {
-    return (
-      <div className="min-h-[calc(100vh-56px)] flex items-center justify-center text-white">
-        초기화 중…
-      </div>
-    );
-  }
+  // 소셜 로그인은 내부에서 redirect URL을 받아 직접 이동(location.assign)
+  const handleGoogle = async () => {
+    setErr("");
+    await loginWithGoogle();
+  };
+  const handleKakao = async () => {
+    setErr("");
+    await loginWithKakao();
+  };
 
   return (
-    <div className="min-h-[calc(100vh-56px)] flex items-center justify-center bg-[#0B0F1E] px-4">
-      <form onSubmit={onSubmit} className="w-full max-w-lg rounded-2xl bg-[#0F1428] p-8 shadow-2xl">
-        <h1 className="mb-6 text-3xl font-extrabold">로그인</h1>
+    <div className="min-h-[calc(100vh-56px)] flex items-center justify-center px-4 text-white">
+      <form onSubmit={onSubmit} className={CARD}>
+        <h1 className={TITLE}>로그인</h1>
 
-        {msg && <p className="mb-3 text-sm text-green-400">{msg}</p>}
-        {error && <p className="mb-3 text-sm text-red-400">{error}</p>}
-
-        <label className="mb-1 block text-sm text-white/70">이메일</label>
+        <label className={LABEL}>이메일</label>
         <input
-          className="mb-4 w-full rounded-lg bg-white/10 px-4 py-2 outline-none focus:ring-2 focus:ring-[#4C6FFF]"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
+          className={INPUT}
+          type="email"
+          name="email"
           placeholder="example@email.com"
+          value={form.email}
+          onChange={onChange}
           autoComplete="email"
-          disabled={submitting}
+          required
         />
 
-        <label className="mb-1 block text-sm text-white/70">비밀번호</label>
-        <input
-          type="password"
-          className="mb-4 w-full rounded-lg bg-white/10 px-4 py-2 outline-none focus:ring-2 focus:ring-[#4C6FFF]"
-          value={pw}
-          onChange={(e) => setPw(e.target.value)}
-          placeholder="영문 대/소문자+숫자 조합"
-          autoComplete="current-password"
-          disabled={submitting}
-        />
-
-        <button
-          type="submit"
-          disabled={submitting}
-          className={`w-full rounded-lg py-3 font-semibold transition ${
-            submitting ? "bg-[#4C6FFF]/60 cursor-wait" : "bg-[#4C6FFF] hover:bg-[#3C59FF]"
-          }`}
-        >
-          {submitting ? "로그인 중…" : "로그인"}
-        </button>
-
-        <div className="mt-3 flex gap-2">
-          <button type="button" disabled className="flex-1 rounded-lg bg-white/10 py-2">Google</button>
-          <button type="button" disabled className="flex-1 rounded-lg bg-[#FFD43B] text-black py-2">Kakao</button>
+        <div className="mt-4">
+          <label className={LABEL}>비밀번호</label>
+          <input
+            className={INPUT}
+            type="password"
+            name="password"
+            placeholder="영문 대/소문자+숫자 조합"
+            value={form.password}
+            onChange={onChange}
+            autoComplete="current-password"
+            required
+          />
         </div>
 
-        <p className="mt-6 text-center text-sm text-white/60">
-          처음이신가요? <Link to="/signup" className="underline">간편 가입</Link>
+        {err && <p className="mt-3 text-sm text-red-400">{err}</p>}
+
+        <button className={`mt-6 ${PRIMARY_BTN}`} disabled={busy}>
+          {busy ? "로그인 중…" : "로그인"}
+        </button>
+
+        <div className="mt-4 grid grid-cols-2 gap-3">
+          <button
+            type="button"
+            className={SECONDARY_BTN}
+            onClick={handleGoogle}
+            aria-label="구글로 로그인"
+          >
+            Google
+          </button>
+          <button
+            type="button"
+            className={KAKAO_BTN}
+            onClick={handleKakao}
+            aria-label="카카오로 로그인"
+          >
+            Kakao
+          </button>
+        </div>
+
+        <p className="mt-6 text-center text-sm text-white/70">
+          처음이신가요?{" "}
+          <Link to="/signup" className="text-[#86a6ff] underline">
+            간편 가입
+          </Link>
         </p>
       </form>
     </div>

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import { Link, useNavigate, useLocation } from "react-router-dom";
+import FormInput from "../components/FormInput.jsx";
+import { isEmail, isPassword } from "../utils/validators.js";
+import useSupabaseAuth from "../hooks/useSupabaseAuth.js";
+import { useAuth } from "../context/AuthContext.jsx";
+
+function Login() {
+  const nav = useNavigate();
+  const loc = useLocation();
+  const { setUser } = useAuth();
+  const { login, loginWithGoogle, loginWithKakao } = useSupabaseAuth();
+
+  const [email, setEmail] = useState("");
+  const [pw, setPw] = useState("");
+  const [errors, setErrors] = useState({});
+  const [submitting, setSubmitting] = useState(false);
+  const [generalError, setGeneralError] = useState("");
+
+  const validate = () => {
+    const e = {};
+    if (!isEmail(email)) e.email = "이메일 형식으로 입력하세요.";
+    if (!isPassword(pw)) e.pw = "영문 대/소문자 + 숫자, 8자 이상";
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  };
+
+  const onSubmit = async (ev) => {
+    ev.preventDefault();
+    setGeneralError("");
+    if (!validate()) return;
+    setSubmitting(true);
+    const { user, error } = await login({ email, password: pw });
+    setSubmitting(false);
+    if (error) return setGeneralError(error.message);
+    setUser(user);
+    const to = new URLSearchParams(loc.search).get("redirect") || "/";
+    nav(to, { replace: true });
+  };
+
+  return (
+    <div className="min-h-[80vh] flex items-center justify-center px-4">
+      <form
+        onSubmit={onSubmit}
+        className={[
+          "w-full max-w-md rounded-2xl",
+          "bg-white/[0.06] border border-white/10 backdrop-blur",
+          "p-7 sm:p-8 shadow-[0_10px_30px_rgba(0,0,0,.35)]",
+        ].join(" ")}
+      >
+        <h1 className="mb-6 text-3xl font-extrabold tracking-tight">로그인</h1>
+
+        <div className="space-y-4">
+          <FormInput
+            label="이메일"
+            value={email}
+            onChange={setEmail}
+            placeholder="example@email.com"
+            error={errors.email}
+          />
+          <FormInput
+            label="비밀번호"
+            type="password"
+            value={pw}
+            onChange={setPw}
+            placeholder="영문 대/소문자+숫자 조합"
+            error={errors.pw}
+          />
+        </div>
+
+        {generalError && (
+          <p className="mt-3 text-sm text-red-400">{generalError}</p>
+        )}
+
+        <button
+          disabled={submitting}
+          className={[
+            "mt-6 w-full rounded-xl py-3.5 text-base font-semibold",
+            "bg-[#3366FF] hover:bg-[#2B55D6] transition-colors",
+            "disabled:opacity-60 disabled:cursor-not-allowed",
+            "shadow-[0_6px_18px_rgba(51,102,255,.35)]",
+          ].join(" ")}
+        >
+          {submitting ? "로그인 중..." : "로그인"}
+        </button>
+
+        <div className="mt-3 grid grid-cols-2 gap-3">
+          <button
+            type="button"
+            onClick={loginWithGoogle}
+            className="rounded-xl border border-white/15 bg-white/5 py-2.5 text-sm hover:bg-white/10"
+            title="Google 로그인"
+          >
+            Google
+          </button>
+          <button
+            type="button"
+            onClick={loginWithKakao}
+            className="rounded-xl bg-[#FEE500] text-[#2B1717] font-semibold py-2.5 text-sm hover:brightness-95"
+            title="Kakao 로그인"
+          >
+            Kakao
+          </button>
+        </div>
+
+        <p className="mt-5 text-center text-sm text-white/70">
+          처음이신가요?{" "}
+          <Link to="/signup" className="underline underline-offset-2 text-white">
+            간편 가입
+          </Link>
+        </p>
+      </form>
+    </div>
+  );
+}
+
+export default Login;

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,117 +1,111 @@
-import { useState } from "react";
-import { Link, useNavigate, useLocation } from "react-router-dom";
-import FormInput from "../components/FormInput.jsx";
-import { isEmail, isPassword } from "../utils/validators.js";
-import useSupabaseAuth from "../hooks/useSupabaseAuth.js";
-import { useAuth } from "../context/AuthContext.jsx";
+import { useEffect, useState } from "react";
+import { useNavigate, useLocation, Link } from "react-router-dom";
+import { login } from "../hooks/useSupabaseAuth";
+import { useAuth } from "../context/AuthContext";
 
-function Login() {
+export default function Login() {
   const nav = useNavigate();
   const loc = useLocation();
-  const { setUser } = useAuth();
-  const { login, loginWithGoogle, loginWithKakao } = useSupabaseAuth();
+  const { user, setUser, loading } = useAuth();
 
   const [email, setEmail] = useState("");
   const [pw, setPw] = useState("");
-  const [errors, setErrors] = useState({});
   const [submitting, setSubmitting] = useState(false);
-  const [generalError, setGeneralError] = useState("");
+  const [msg, setMsg] = useState(loc.state?.msg || "");
+  const [error, setError] = useState("");
 
-  const validate = () => {
-    const e = {};
-    if (!isEmail(email)) e.email = "이메일 형식으로 입력하세요.";
-    if (!isPassword(pw)) e.pw = "영문 대/소문자 + 숫자, 8자 이상";
-    setErrors(e);
-    return Object.keys(e).length === 0;
-  };
+  // 로그인되어 있으면 이 페이지에 머물 이유가 없음
+  useEffect(() => {
+    if (!loading && user) nav("/", { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, user]);
 
-  const onSubmit = async (ev) => {
-    ev.preventDefault();
-    setGeneralError("");
-    if (!validate()) return;
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    if (submitting) return;
+
+    setError("");
+    setMsg("");
     setSubmitting(true);
-    const { user, error } = await login({ email, password: pw });
-    setSubmitting(false);
-    if (error) return setGeneralError(error.message);
-    setUser(user);
-    const to = new URLSearchParams(loc.search).get("redirect") || "/";
-    nav(to, { replace: true });
+
+    try {
+      const { user: u, error: err } = await login({ email, password: pw });
+
+      if (err) {
+        const pretty =
+          err.message === "Invalid login credentials"
+            ? "이메일/비밀번호가 올바르지 않거나 이메일 인증이 완료되지 않았습니다."
+            : err.message || "로그인 실패";
+        setError(pretty);
+        return;
+      }
+
+      setUser(u);                 // ✅ 전역 상태 갱신
+      nav("/", { replace: true }); // ✅ 즉시 이동
+    } catch (ex) {
+      setError(ex?.message || "알 수 없는 오류가 발생했습니다.");
+    } finally {
+      setSubmitting(false);        // ✅ 절대 멈추지 않게
+    }
   };
+
+  // 초기 세션 복구 중이면 살짝 로딩만
+  if (loading) {
+    return (
+      <div className="min-h-[calc(100vh-56px)] flex items-center justify-center text-white">
+        초기화 중…
+      </div>
+    );
+  }
 
   return (
-    <div className="min-h-[80vh] flex items-center justify-center px-4">
-      <form
-        onSubmit={onSubmit}
-        className={[
-          "w-full max-w-md rounded-2xl",
-          "bg-white/[0.06] border border-white/10 backdrop-blur",
-          "p-7 sm:p-8 shadow-[0_10px_30px_rgba(0,0,0,.35)]",
-        ].join(" ")}
-      >
-        <h1 className="mb-6 text-3xl font-extrabold tracking-tight">로그인</h1>
+    <div className="min-h-[calc(100vh-56px)] flex items-center justify-center bg-[#0B0F1E] px-4">
+      <form onSubmit={onSubmit} className="w-full max-w-lg rounded-2xl bg-[#0F1428] p-8 shadow-2xl">
+        <h1 className="mb-6 text-3xl font-extrabold">로그인</h1>
 
-        <div className="space-y-4">
-          <FormInput
-            label="이메일"
-            value={email}
-            onChange={setEmail}
-            placeholder="example@email.com"
-            error={errors.email}
-          />
-          <FormInput
-            label="비밀번호"
-            type="password"
-            value={pw}
-            onChange={setPw}
-            placeholder="영문 대/소문자+숫자 조합"
-            error={errors.pw}
-          />
-        </div>
+        {msg && <p className="mb-3 text-sm text-green-400">{msg}</p>}
+        {error && <p className="mb-3 text-sm text-red-400">{error}</p>}
 
-        {generalError && (
-          <p className="mt-3 text-sm text-red-400">{generalError}</p>
-        )}
+        <label className="mb-1 block text-sm text-white/70">이메일</label>
+        <input
+          className="mb-4 w-full rounded-lg bg-white/10 px-4 py-2 outline-none focus:ring-2 focus:ring-[#4C6FFF]"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="example@email.com"
+          autoComplete="email"
+          disabled={submitting}
+        />
+
+        <label className="mb-1 block text-sm text-white/70">비밀번호</label>
+        <input
+          type="password"
+          className="mb-4 w-full rounded-lg bg-white/10 px-4 py-2 outline-none focus:ring-2 focus:ring-[#4C6FFF]"
+          value={pw}
+          onChange={(e) => setPw(e.target.value)}
+          placeholder="영문 대/소문자+숫자 조합"
+          autoComplete="current-password"
+          disabled={submitting}
+        />
 
         <button
+          type="submit"
           disabled={submitting}
-          className={[
-            "mt-6 w-full rounded-xl py-3.5 text-base font-semibold",
-            "bg-[#3366FF] hover:bg-[#2B55D6] transition-colors",
-            "disabled:opacity-60 disabled:cursor-not-allowed",
-            "shadow-[0_6px_18px_rgba(51,102,255,.35)]",
-          ].join(" ")}
+          className={`w-full rounded-lg py-3 font-semibold transition ${
+            submitting ? "bg-[#4C6FFF]/60 cursor-wait" : "bg-[#4C6FFF] hover:bg-[#3C59FF]"
+          }`}
         >
-          {submitting ? "로그인 중..." : "로그인"}
+          {submitting ? "로그인 중…" : "로그인"}
         </button>
 
-        <div className="mt-3 grid grid-cols-2 gap-3">
-          <button
-            type="button"
-            onClick={loginWithGoogle}
-            className="rounded-xl border border-white/15 bg-white/5 py-2.5 text-sm hover:bg-white/10"
-            title="Google 로그인"
-          >
-            Google
-          </button>
-          <button
-            type="button"
-            onClick={loginWithKakao}
-            className="rounded-xl bg-[#FEE500] text-[#2B1717] font-semibold py-2.5 text-sm hover:brightness-95"
-            title="Kakao 로그인"
-          >
-            Kakao
-          </button>
+        <div className="mt-3 flex gap-2">
+          <button type="button" disabled className="flex-1 rounded-lg bg-white/10 py-2">Google</button>
+          <button type="button" disabled className="flex-1 rounded-lg bg-[#FFD43B] text-black py-2">Kakao</button>
         </div>
 
-        <p className="mt-5 text-center text-sm text-white/70">
-          처음이신가요?{" "}
-          <Link to="/signup" className="underline underline-offset-2 text-white">
-            간편 가입
-          </Link>
+        <p className="mt-6 text-center text-sm text-white/60">
+          처음이신가요? <Link to="/signup" className="underline">간편 가입</Link>
         </p>
       </form>
     </div>
   );
 }
-
-export default Login;

--- a/src/pages/MyBookmark.jsx
+++ b/src/pages/MyBookmark.jsx
@@ -1,0 +1,43 @@
+// src/pages/MyBookmark.jsx
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import MediaCard from "../components/MediaCard.jsx";
+import bookmark from "../lib/bookmark.js"; // default export 사용
+
+export default function MyBookmark() {
+  const [items, setItems] = useState(() => bookmark.list());
+
+  useEffect(() => {
+    // 변경 구독
+    const off = bookmark.subscribe(setItems);
+    // 마운트 시 동기화
+    setItems(bookmark.list());
+    return off;
+  }, []);
+
+  return (
+    <div className="min-h-[calc(100vh-56px)] px-4 py-8 text-white">
+      <div className="mx-auto w-[min(92vw,1200px)] rounded-2xl bg-[#1b2038] border border-white/10 p-6 md:p-8">
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-extrabold tracking-tight md:text-3xl">BOOKMARK</h2>
+          <Link to="/mypage" className="text-sm text-white/70 hover:text-white">
+            ← 마이페이지
+          </Link>
+        </div>
+        <hr className="mt-4 border-white/10" />
+
+        {items.length ? (
+          <div className="grid grid-cols-2 gap-4 mt-6 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+            {items.map((m) => (
+              <MediaCard key={m.id} item={m} />
+            ))}
+          </div>
+        ) : (
+          <p className="mt-6 text-white/60">
+            아직 북마크한 작품이 없어요. 상세 페이지에서 <b>북마크</b> 버튼을 눌러 추가하세요.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,0 +1,62 @@
+// src/pages/MyPage.jsx
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext.jsx";
+
+export default function MyPage() {
+  const { user } = useAuth();
+  const nav = useNavigate();
+
+  return (
+    <div className="min-h-[calc(100vh-56px)] px-4 py-10 text-white">
+      {/* 프로필 카드 */}
+      <div className="mx-auto w-[min(92vw,1000px)] rounded-2xl bg-[#0E1324] border border-white/10 p-6 md:p-8">
+        <div className="flex items-center gap-5">
+          <img
+            src={user.profileImageUrl}
+            alt="avatar"
+            className="object-cover w-20 h-20 border rounded-full border-white/10"
+          />
+          <div>
+            <h1 className="text-2xl font-extrabold">{user.userName || "닉네임 없음"}</h1>
+            <p className="mt-1 text-white/70">{user.email}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* 액션 카드 2개: 위시리스트 / 북마크 */}
+      <div className="mx-auto mt-6 w-[min(92vw,1000px)] grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* 위시리스트 카드 */}
+        <button
+          type="button"
+          onClick={() => nav("/mypage/wishlist")}
+          className="group flex items-center justify-between rounded-2xl bg-[#121833] border border-white/10 p-6
+                     hover:bg-[#172044] transition text-left"
+        >
+          <div>
+            <h2 className="text-xl font-bold">위시리스트</h2>
+            <p className="mt-1 text-sm text-white/70">내가 ♥ 로 저장한 콘텐츠</p>
+          </div>
+          <span className="ml-4 text-white/60 text-2xl group-hover:translate-x-0.5 transition" aria-hidden>
+            ›
+          </span>
+        </button>
+
+        {/* 북마크 카드 */}
+        <button
+          type="button"
+          onClick={() => nav("/mypage/bookmark")}
+          className="group flex items-center justify-between rounded-2xl bg-[#121833] border border-white/10 p-6
+                     hover:bg-[#172044] transition text-left"
+        >
+          <div>
+            <h2 className="text-xl font-bold">북마크</h2>
+            <p className="mt-1 text-sm text-white/70">상세 페이지에서 북마크한 콘텐츠</p>
+          </div>
+          <span className="ml-4 text-white/60 text-2xl group-hover:translate-x-0.5 transition" aria-hidden>
+            ›
+          </span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/MyWishlist.jsx
+++ b/src/pages/MyWishlist.jsx
@@ -1,0 +1,40 @@
+// src/pages/MyWishlist.jsx
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import MediaCard from "../components/MediaCard.jsx";
+import { list as wishList, subscribe as wishSubscribe } from "../lib/wishlist.js";
+
+export default function MyWishlist() {
+  const [items, setItems] = useState(() => wishList());
+
+  useEffect(() => {
+    // 최초 로드 + 변경 구독
+    const off = wishSubscribe(setItems);
+    setItems(wishList());
+    return off;
+  }, []);
+
+  return (
+    <div className="min-h-[calc(100vh-56px)] px-4 py-8 text-white">
+      <div className="mx-auto w-[min(92vw,1200px)] rounded-2xl bg-[#1b2038] border border-white/10 p-6 md:p-8">
+        <div className="flex items-center justify-between">
+          <h2 className="text-2xl font-extrabold tracking-tight md:text-3xl">WISHLIST</h2>
+          <Link to="/mypage" className="text-sm text-white/70 hover:text-white">← 마이페이지</Link>
+        </div>
+        <hr className="mt-4 border-white/10" />
+
+        {items.length ? (
+          <div className="grid grid-cols-2 gap-4 mt-6 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+            {items.map((m) => (
+              <MediaCard key={m.id} item={m} />
+            ))}
+          </div>
+        ) : (
+          <p className="mt-6 text-white/60">
+            아직 찜한 작품이 없어요. 목록의 카드에서 ♥를 눌러 추가해보세요.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/RootPage.jsx
+++ b/src/pages/RootPage.jsx
@@ -1,0 +1,36 @@
+// src/pages/RootPage.jsx
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import Home from "./Home.jsx";
+import SearchResults from "./SearchResults.jsx";
+import { fetchPopularMovies, fetchTrendingMovies, fetchTopRatedMovies } from "../api/tmdb.js";
+
+function RootPage() {
+  const [params] = useSearchParams();
+  const q = (params.get("q") || "").trim();
+
+  const [pool, setPool] = useState([]);
+  useEffect(() => {
+    if (!q) return;
+    let alive = true;
+    (async () => {
+      try {
+        const [p, t, r] = await Promise.all([
+          fetchPopularMovies(1),
+          fetchTrendingMovies("week"),
+          fetchTopRatedMovies(1),
+        ]);
+        if (!alive) return;
+        const clean = (x) => (x?.results || []).filter((m) => !m.adult);
+        setPool([...clean(p), ...clean(t), ...clean(r)]);
+      } catch {
+        setPool([]);
+      }
+    })();
+    return () => { alive = false; };
+  }, [q]);
+
+  return q ? <SearchResults fallbackPool={pool} /> : <Home />;
+}
+
+export default RootPage;  // ✅ 기본 내보내기

--- a/src/pages/SearchResults.jsx
+++ b/src/pages/SearchResults.jsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { searchMovies } from "../api/tmdb.js";
+import SectionHeader from "../components/SectionHeader.jsx";
+import MediaCard from "../components/MediaCard.jsx";
+import { includesChoseong, isChoseongQuery } from "../utils/korean.js";
+
+function SearchResults({ fallbackPool = [] }) {
+  const [params] = useSearchParams();
+  const q = (params.get("q") || "").trim();
+  const [loading, setLoading] = useState(true);
+  const [items, setItems] = useState([]);
+
+  useEffect(() => {
+    let alive = true;
+    if (!q) {
+      setItems([]);
+      setLoading(false);
+      return;
+    }
+    (async () => {
+      setLoading(true);
+      try {
+        const list = [];
+
+        // 1) TMDB 검색
+        try {
+          const api = await searchMovies(q, 1);
+          if (api?.results) list.push(...api.results.filter((m) => !m.adult));
+        } catch (_) {}
+
+        // 2) 초성 쿼리 → 로컬 풀 검색 보강
+        if (isChoseongQuery(q) && Array.isArray(fallbackPool)) {
+          const extra = fallbackPool.filter((m) =>
+            includesChoseong(m.title || "", q)
+          );
+          list.push(...extra);
+        }
+
+        // 3) 중복 제거
+        const uniq = Array.from(new Map(list.map((m) => [m.id, m])).values());
+        if (alive) setItems(uniq);
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [q, fallbackPool]);
+
+  return (
+    <section className="mx-auto max-w-[1400px] px-4 md:px-6 py-6 space-y-6">
+      <SectionHeader title="검색 결과" />
+      {loading ? (
+        <p className="text-white/70">검색 중…</p>
+      ) : items.length ? (
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-7">
+          {items.map((m) => (
+            <MediaCard key={m.id} item={m} />
+          ))}
+        </div>
+      ) : (
+        <p className="text-white/60">"{q}"에 대한 결과가 없습니다.</p>
+      )}
+    </section>
+  );
+}
+
+export default SearchResults;   // ✅ 기본 내보내기

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -1,120 +1,123 @@
-// src/pages/Signup.jsx
 import { useState } from "react";
-import { Link, useNavigate, useLocation } from "react-router-dom";
-import FormInput from "../components/FormInput.jsx";
-import { isEmail, isPassword, isName, equals } from "../utils/validators.js";
-import useSupabaseAuth from "../hooks/useSupabaseAuth.js";
-import { useAuth } from "../context/AuthContext.jsx";
+import { Link, useNavigate } from "react-router-dom";
+import { signup } from "../hooks/useSupabaseAuth";
+import { isEmail, isName, isPassword, equals } from "../utils/validators";
 
-function Signup() {
+const CARD =
+  "mx-auto w-[min(92vw,560px)] rounded-2xl bg-[#0E1324] shadow-2xl border border-white/10 p-8 md:p-10";
+const TITLE = "text-3xl md:text-4xl font-extrabold mb-8";
+const LABEL = "block mb-2 text-sm text-white/70";
+const INPUT =
+  "w-full h-12 rounded-lg bg-white/10 text-white placeholder-white/50 px-4 outline-none focus:ring-2 focus:ring-[rgba(51,102,255,.45)]";
+const PRIMARY_BTN =
+  "w-full h-12 rounded-lg bg-[#3867FF] hover:brightness-110 text-white font-semibold transition";
+
+export default function Signup() {
   const nav = useNavigate();
-  const loc = useLocation();
-  const { setUser } = useAuth();
-  const { signup } = useSupabaseAuth();
+  const [form, setForm] = useState({
+    email: "",
+    userName: "",
+    password: "",
+    confirm: "",
+  });
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState("");
 
-  const [email, setEmail] = useState("");
-  const [name, setName] = useState("");
-  const [pw, setPw] = useState("");
-  const [pw2, setPw2] = useState("");
-
-  const [errors, setErrors] = useState({});
-  const [submitting, setSubmitting] = useState(false);
-  const [generalError, setGeneralError] = useState("");
+  const onChange = (e) => setForm({ ...form, [e.target.name]: e.target.value });
 
   const validate = () => {
-    const e = {};
-    if (!isEmail(email)) e.email = "이메일 형식으로 입력하세요.";
-    if (!isName(name)) e.name = "2~8자, 한글·영문·숫자만 사용";
-    if (!isPassword(pw)) e.pw = "영문 대/소문자 + 숫자, 8자 이상";
-    if (!equals(pw, pw2)) e.pw2 = "비밀번호가 일치하지 않습니다.";
-    setErrors(e);
-    return Object.keys(e).length === 0;
+    if (!isEmail(form.email)) return "이메일 형식을 확인해 주세요.";
+    if (!isName(form.userName)) return "이름은 2~8자, 한글/영어/숫자만 가능합니다.";
+    if (!isPassword(form.password))
+      return "비밀번호는 영문 대/소문자 + 숫자 조합(8자 이상).";
+    if (!equals(form.password, form.confirm)) return "비밀번호가 일치하지 않습니다.";
+    return "";
   };
 
-  const onSubmit = async (ev) => {
-    ev.preventDefault();
-    setGeneralError("");
-    if (!validate()) return;
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    if (busy) return;
+    const v = validate();
+    if (v) return setErr(v);
 
-    setSubmitting(true);
-    const { user, error } = await signup({ email, password: pw, userName: name });
-    setSubmitting(false);
+    setBusy(true);
+    setErr("");
+    const { error } = await signup({
+      email: form.email,
+      password: form.password,
+      userName: form.userName,
+    });
+    setBusy(false);
+    if (error) return setErr(error.message || "회원가입 실패");
 
-    if (error) {
-      setGeneralError(error.message || "회원가입 실패");
-      return;
-    }
-
-    // 전역 유저 상태 반영 후 이동
-    setUser(user);
-    const to = new URLSearchParams(loc.search).get("redirect") || "/";
-    nav(to, { replace: true });
+    // 회원가입 → 자동 로그인되면 홈으로
+    nav("/", { replace: true });
   };
 
   return (
-    <div className="min-h-[80vh] flex items-center justify-center px-4">
-      <form
-        onSubmit={onSubmit}
-        className={[
-          "w-full max-w-md rounded-2xl",
-          "bg-white/[0.06] border border-white/10 backdrop-blur",
-          "p-7 sm:p-8 shadow-[0_10px_30px_rgba(0,0,0,.35)]",
-        ].join(" ")}
-      >
-        <h1 className="mb-6 text-3xl font-extrabold tracking-tight">회원가입</h1>
+    <div className="min-h-[calc(100vh-56px)] flex items-center justify-center px-4 text-white">
+      <form onSubmit={onSubmit} className={CARD}>
+        <h1 className={TITLE}>회원가입</h1>
 
-        <div className="space-y-4">
-          <FormInput
-            label="이메일"
-            value={email}
-            onChange={setEmail}
-            placeholder="example@email.com"
-            error={errors.email}
-          />
-          <FormInput
-            label="이름"
-            value={name}
-            onChange={setName}
+        <label className={LABEL}>이메일</label>
+        <input
+          className={INPUT}
+          type="email"
+          name="email"
+          placeholder="example@email.com"
+          value={form.email}
+          onChange={onChange}
+          autoComplete="email"
+        />
+
+        <div className="mt-4">
+          <label className={LABEL}>이름</label>
+          <input
+            className={INPUT}
+            type="text"
+            name="userName"
             placeholder="2~8자, 숫자·한글·영어"
-            error={errors.name}
-          />
-          <FormInput
-            label="비밀번호"
-            type="password"
-            value={pw}
-            onChange={setPw}
-            placeholder="영문 대/소문자 + 숫자"
-            error={errors.pw}
-          />
-          <FormInput
-            label="비밀번호 확인"
-            type="password"
-            value={pw2}
-            onChange={setPw2}
-            placeholder="동일하게 입력"
-            error={errors.pw2}
+            value={form.userName}
+            onChange={onChange}
+            autoComplete="nickname"
           />
         </div>
 
-        {generalError && (
-          <p className="mt-3 text-sm text-red-400">{generalError}</p>
-        )}
+        <div className="mt-4">
+          <label className={LABEL}>비밀번호</label>
+          <input
+            className={INPUT}
+            type="password"
+            name="password"
+            placeholder="영문 대/소문자 + 숫자"
+            value={form.password}
+            onChange={onChange}
+            autoComplete="new-password"
+          />
+        </div>
 
-        <button
-          disabled={submitting}
-          className={[
-            "mt-6 w-full rounded-xl py-3.5 text-base font-semibold",
-            "bg-[#3366FF] hover:bg-[#2B55D6] transition-colors",
-            "disabled:opacity-60 disabled:cursor-not-allowed",
-            "shadow-[0_6px_18px_rgba(51,102,255,.35)]",
-          ].join(" ")}
-        >
-          {submitting ? "가입 중..." : "회원가입"}
+        <div className="mt-4">
+          <label className={LABEL}>비밀번호 확인</label>
+          <input
+            className={INPUT}
+            type="password"
+            name="confirm"
+            placeholder="동일하게 입력"
+            value={form.confirm}
+            onChange={onChange}
+            autoComplete="new-password"
+          />
+        </div>
+
+        {err && <p className="mt-3 text-sm text-red-400">{err}</p>}
+
+        <button className={`mt-6 ${PRIMARY_BTN}`} disabled={busy}>
+          {busy ? "가입 중…" : "회원가입"}
         </button>
 
-        <p className="mt-5 text-center text-sm text-white/70">
+        <p className="mt-6 text-center text-sm text-white/70">
           이미 계정이 있으신가요?{" "}
-          <Link to="/login" className="underline underline-offset-2 text-white">
+          <Link to="/login" className="text-[#86a6ff] underline">
             로그인
           </Link>
         </p>
@@ -122,5 +125,3 @@ function Signup() {
     </div>
   );
 }
-
-export default Signup;

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -1,0 +1,126 @@
+// src/pages/Signup.jsx
+import { useState } from "react";
+import { Link, useNavigate, useLocation } from "react-router-dom";
+import FormInput from "../components/FormInput.jsx";
+import { isEmail, isPassword, isName, equals } from "../utils/validators.js";
+import useSupabaseAuth from "../hooks/useSupabaseAuth.js";
+import { useAuth } from "../context/AuthContext.jsx";
+
+function Signup() {
+  const nav = useNavigate();
+  const loc = useLocation();
+  const { setUser } = useAuth();
+  const { signup } = useSupabaseAuth();
+
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [pw, setPw] = useState("");
+  const [pw2, setPw2] = useState("");
+
+  const [errors, setErrors] = useState({});
+  const [submitting, setSubmitting] = useState(false);
+  const [generalError, setGeneralError] = useState("");
+
+  const validate = () => {
+    const e = {};
+    if (!isEmail(email)) e.email = "이메일 형식으로 입력하세요.";
+    if (!isName(name)) e.name = "2~8자, 한글·영문·숫자만 사용";
+    if (!isPassword(pw)) e.pw = "영문 대/소문자 + 숫자, 8자 이상";
+    if (!equals(pw, pw2)) e.pw2 = "비밀번호가 일치하지 않습니다.";
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  };
+
+  const onSubmit = async (ev) => {
+    ev.preventDefault();
+    setGeneralError("");
+    if (!validate()) return;
+
+    setSubmitting(true);
+    const { user, error } = await signup({ email, password: pw, userName: name });
+    setSubmitting(false);
+
+    if (error) {
+      setGeneralError(error.message || "회원가입 실패");
+      return;
+    }
+
+    // 전역 유저 상태 반영 후 이동
+    setUser(user);
+    const to = new URLSearchParams(loc.search).get("redirect") || "/";
+    nav(to, { replace: true });
+  };
+
+  return (
+    <div className="min-h-[80vh] flex items-center justify-center px-4">
+      <form
+        onSubmit={onSubmit}
+        className={[
+          "w-full max-w-md rounded-2xl",
+          "bg-white/[0.06] border border-white/10 backdrop-blur",
+          "p-7 sm:p-8 shadow-[0_10px_30px_rgba(0,0,0,.35)]",
+        ].join(" ")}
+      >
+        <h1 className="mb-6 text-3xl font-extrabold tracking-tight">회원가입</h1>
+
+        <div className="space-y-4">
+          <FormInput
+            label="이메일"
+            value={email}
+            onChange={setEmail}
+            placeholder="example@email.com"
+            error={errors.email}
+          />
+          <FormInput
+            label="이름"
+            value={name}
+            onChange={setName}
+            placeholder="2~8자, 숫자·한글·영어"
+            error={errors.name}
+          />
+          <FormInput
+            label="비밀번호"
+            type="password"
+            value={pw}
+            onChange={setPw}
+            placeholder="영문 대/소문자 + 숫자"
+            error={errors.pw}
+          />
+          <FormInput
+            label="비밀번호 확인"
+            type="password"
+            value={pw2}
+            onChange={setPw2}
+            placeholder="동일하게 입력"
+            error={errors.pw2}
+          />
+        </div>
+
+        {generalError && (
+          <p className="mt-3 text-sm text-red-400">{generalError}</p>
+        )}
+
+        <button
+          disabled={submitting}
+          className={[
+            "mt-6 w-full rounded-xl py-3.5 text-base font-semibold",
+            "bg-[#3366FF] hover:bg-[#2B55D6] transition-colors",
+            "disabled:opacity-60 disabled:cursor-not-allowed",
+            "shadow-[0_6px_18px_rgba(51,102,255,.35)]",
+          ].join(" ")}
+        >
+          {submitting ? "가입 중..." : "회원가입"}
+        </button>
+
+        <p className="mt-5 text-center text-sm text-white/70">
+          이미 계정이 있으신가요?{" "}
+          <Link to="/login" className="underline underline-offset-2 text-white">
+            로그인
+          </Link>
+        </p>
+      </form>
+    </div>
+  );
+}
+
+export default Signup;

--- a/src/pages/Top.jsx
+++ b/src/pages/Top.jsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import { fetchTopRatedMovies } from "../api/tmdb.js";
+import SectionHeader from "../components/SectionHeader.jsx";
+import MediaCard from "../components/MediaCard.jsx";
+
+function Top() {
+  const [page, setPage] = useState(1);
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      setLoading(true);
+      try {
+        const r = await fetchTopRatedMovies(page);
+        if (alive) setItems((r.results || []).filter((m) => !m.adult));
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => { alive = false; };
+  }, [page]);
+
+  return (
+    <div className="mx-auto max-w-[1400px] px-4 md:px-6 py-8 space-y-6">
+      <SectionHeader title="평점이 높은 작품" />
+      {loading ? (
+        <p className="text-white/70">불러오는 중…</p>
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-7">
+            {items.map((m) => (
+              <MediaCard key={m.id} item={m} />
+            ))}
+          </div>
+
+          <div className="flex items-center justify-center gap-3 pt-6">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              className="px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/15 disabled:opacity-50"
+              disabled={page === 1}
+            >
+              이전
+            </button>
+            <span className="text-white/70 text-sm">페이지 {page}</span>
+            <button
+              onClick={() => setPage((p) => p + 1)}
+              className="px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/15"
+            >
+              다음
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default Top;   // ✅ 반드시 추가

--- a/src/pages/Top.jsx
+++ b/src/pages/Top.jsx
@@ -1,60 +1,95 @@
-import { useEffect, useState } from "react";
+// src/pages/Top.jsx
+import { useEffect, useRef, useState, useCallback } from "react";
 import { fetchTopRatedMovies } from "../api/tmdb.js";
 import SectionHeader from "../components/SectionHeader.jsx";
 import MediaCard from "../components/MediaCard.jsx";
+import useThrottle from "../hooks/useThrottle.js";
 
 function Top() {
-  const [page, setPage] = useState(1);
+  const [page, setPage] = useState(0);          // 마지막으로 로드 완료한 페이지 번호
   const [items, setItems] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [done, setDone] = useState(false);      // 더 이상 불러올 게 없을 때
+  const guardRef = useRef(null);
+  const fetchingRef = useRef(false);            // 동시/중복 요청 방지
+
+  const loadPage = useCallback(async (nextPage) => {
+    if (fetchingRef.current || done) return;
+    fetchingRef.current = true;
+    setLoading(true);
+    try {
+      const r = await fetchTopRatedMovies(nextPage);
+      const rows = (r.results || []).filter((m) => !m.adult);
+      setItems((prev) => prev.concat(rows));
+      setPage(nextPage);
+      if (!rows.length || nextPage >= (r.total_pages || 500)) {
+        setDone(true);
+      }
+    } catch {
+      // 실패 시 다음 기회에 다시 시도할 수 있게만 처리
+    } finally {
+      setLoading(false);
+      fetchingRef.current = false;
+    }
+  }, [done]);
+
+  // 초기 1페이지
+  useEffect(() => {
+    loadPage(1);
+  }, [loadPage]);
+
+  // sentinel이 보이면 다음 페이지 로드
+  const throttledLoad = useThrottle((p) => loadPage(p), 700);
 
   useEffect(() => {
-    let alive = true;
-    (async () => {
-      setLoading(true);
-      try {
-        const r = await fetchTopRatedMovies(page);
-        if (alive) setItems((r.results || []).filter((m) => !m.adult));
-      } finally {
-        if (alive) setLoading(false);
+    const el = guardRef.current;
+    if (!el || done) return;
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        const visible = entries.some((e) => e.isIntersecting);
+        if (visible) throttledLoad(page + 1);
+      },
+      {
+        root: null,
+        // 화면 아래쪽에 여유를 넉넉히 줘서 빨리 당겨오기
+        rootMargin: "800px 0px",
+        threshold: 0,
       }
-    })();
-    return () => { alive = false; };
-  }, [page]);
+    );
+
+    io.observe(el);
+    return () => io.disconnect();
+  }, [page, done, throttledLoad]);
+
+  // 화면에 스크롤이 안 생기면 자동으로 추가 로드(뷰포트 채우기 보정)
+  useEffect(() => {
+    if (done || loading) return;
+    const notScrollable =
+      document.documentElement.scrollHeight <= window.innerHeight + 100;
+    if (notScrollable && page >= 1) {
+      throttledLoad(page + 1);
+    }
+  }, [items, page, loading, done, throttledLoad]);
 
   return (
     <div className="mx-auto max-w-[1400px] px-4 md:px-6 py-8 space-y-6">
-      <SectionHeader title="평점이 높은 작품" />
-      {loading ? (
-        <p className="text-white/70">불러오는 중…</p>
-      ) : (
-        <>
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-7">
-            {items.map((m) => (
-              <MediaCard key={m.id} item={m} />
-            ))}
-          </div>
+      <SectionHeader title="평점이 높은 작품 (무한 스크롤)" />
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-7">
+        {items.map((m) => (
+          <MediaCard key={`${m.id}-${m.title}`} item={m} />
+        ))}
+      </div>
 
-          <div className="flex items-center justify-center gap-3 pt-6">
-            <button
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
-              className="px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/15 disabled:opacity-50"
-              disabled={page === 1}
-            >
-              이전
-            </button>
-            <span className="text-white/70 text-sm">페이지 {page}</span>
-            <button
-              onClick={() => setPage((p) => p + 1)}
-              className="px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/15"
-            >
-              다음
-            </button>
-          </div>
-        </>
-      )}
+      <div className="py-6 text-center text-white/70">
+        {loading && <p>불러오는 중…</p>}
+        {done && <p>모든 데이터를 불러왔습니다.</p>}
+      </div>
+
+      {/* 관찰용 센티넬 */}
+      <div ref={guardRef} className="h-4" />
     </div>
   );
 }
 
-export default Top;   // ✅ 반드시 추가
+export default Top;

--- a/src/pages/Trending.jsx
+++ b/src/pages/Trending.jsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import { fetchTrendingMovies } from "../api/tmdb.js";
+import SectionHeader from "../components/SectionHeader.jsx";
+import MediaCard from "../components/MediaCard.jsx";
+
+function Trending() {
+  const [items, setItems] = useState([]);
+  const [time, setTime] = useState("day"); // "day" or "week"
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      setLoading(true);
+      try {
+        const r = await fetchTrendingMovies(time);
+        if (alive) setItems((r.results || []).filter((m) => !m.adult));
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [time]);
+
+  return (
+    <div className="mx-auto max-w-[1400px] px-4 md:px-6 py-8 space-y-6">
+      <SectionHeader title="실시간 인기 콘텐츠" />
+      <div className="flex gap-2">
+        {["day", "week"].map((t) => (
+          <button
+            key={t}
+            onClick={() => setTime(t)}
+            className={
+              "px-3 py-1.5 rounded-lg text-sm " +
+              (time === t
+                ? "bg-[#3366FF] text-white"
+                : "bg-white/10 text-white/80 hover:bg-white/15")
+            }
+          >
+            {t === "day" ? "오늘" : "이번 주"}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <p className="text-white/70">불러오는 중…</p>
+      ) : (
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-7 pb-10">
+          {items.map((m) => (
+            <MediaCard key={m.id} item={m} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default Trending; // ✅ 반드시 추가

--- a/src/routes/RequireAuth.jsx
+++ b/src/routes/RequireAuth.jsx
@@ -1,0 +1,16 @@
+// src/routes/RequireAuth.jsx
+import { Navigate, useLocation } from "react-router-dom";
+import { useAuth } from "../context/AuthContext.jsx";
+
+export default function RequireAuth({ children }) {
+  const { ready, user } = useAuth();
+  const loc = useLocation();
+
+  if (!ready) return null; // 세션 확인 중
+
+  if (!user) {
+    const next = encodeURIComponent(loc.pathname + loc.search);
+    return <Navigate to={`/login?next=${next}`} replace />;
+  }
+  return children;
+}

--- a/src/utils/korean.js
+++ b/src/utils/korean.js
@@ -1,0 +1,24 @@
+const CHOSEONG = [
+  "ㄱ","ㄲ","ㄴ","ㄷ","ㄸ","ㄹ","ㅁ","ㅂ","ㅃ","ㅅ",
+  "ㅆ","ㅇ","ㅈ","ㅉ","ㅊ","ㅋ","ㅌ","ㅍ","ㅎ",
+];
+
+export function toChoseong(str = "") {
+  let out = "";
+  for (const ch of String(str)) {
+    const code = ch.charCodeAt(0);
+    if (code >= 0xac00 && code <= 0xd7a3) {
+      const idx = Math.floor((code - 0xac00) / 588);
+      out += CHOSEONG[idx];
+    } else if (/[ㄱ-ㅎ]/.test(ch)) out += ch;
+  }
+  return out;
+}
+
+export function isChoseongQuery(q = "") {
+  return q.trim() !== "" && /^[ㄱ-ㅎ]+$/.test(q.trim());
+}
+
+export function includesChoseong(title = "", q = "") {
+  return toChoseong(title).includes(q.trim());
+}

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -1,0 +1,24 @@
+// src/utils/validators.js
+
+/** 이메일 형식 검증 */
+export function isEmail(value) {
+  if (!value) return false;
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+/** 이름 검증: 2~8자, 한글/영문/숫자만 허용 */
+export function isName(value) {
+  if (!value) return false;
+  return /^[A-Za-z0-9가-힣]{2,8}$/.test(value);
+}
+
+/** 비밀번호 검증: 영문 대/소문자 + 숫자 포함, 8자 이상 */
+export function isPassword(value) {
+  if (!value) return false;
+  return /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[A-Za-z\d]{8,}$/.test(value);
+}
+
+/** 두 값이 같은지 확인 */
+export function equals(a, b) {
+  return a === b;
+}


### PR DESCRIPTION
[mission5] 5단계 미션 구현 - 장동욱/개인

## 구현 사항
-마이페이지 분기
/mypage에 위시리스트 / 북마크 카드 2개 추가 → 각 카드 클릭 시
/mypage/wishlist (위시리스트)
/mypage/bookmark (북마크)
RequireAuth로 보호 라우팅(비로그인 접근 시 로그인 페이지로 안내).
북마크 기능 (상세 페이지 전용)
MovieDetail.jsx에 북마크 토글 버튼 추가.
비로그인 상태에서 클릭 시 alert("로그인이 필요합니다") 후 /login?next=현재경로로 이동.
src/lib/bookmark.js 구현
list / has / add / remove / toggle / subscribe + default export 제공.
localStorage(bookmark_v1) 기반으로 데이터 영속화.
커스텀 이벤트(bookmark:change)로 페이지 간 상태 동기화.
북마크 목록 페이지
src/pages/MyBookmark.jsx 생성.
마운트 시 bookmark.list()로 초기 로딩, bookmark.subscribe()로 실시간 반영.
MediaCard를 재사용해 그리드로 렌더링.
위시리스트 유지
기존 위시리스트는 wishlist.js(로컬 저장) + /mypage/wishlist로 분리 유지.
마이페이지에서 위시리스트 / 북마크를 명확히 구분하여 이동.
내브바
로그인 시 아바타 메뉴에 마이페이지 항목 추가(클릭 → /mypage).
로그아웃 버튼 동작 및 세션 정리.
기타(기존 구현과 연동)
TMDB API 연동(인기/실시간/평점/장르/검색).
초성 검색 보강(ㄱㄴㄷ) 로직 유지.

## 어려웠던 점
ESM import/export 충돌
does not provide an export named 'default' / is not a function 등 오류가 발생.
해결: 유틸 모듈(bookmark.js)에 named export + default export를 모두 제공하고,
페이지 레벨에서는 default import로 일관되게 사용.
라우터 보호 흐름
북마크 클릭 시 비로그인 처리: 현재 경로를 next 쿼리로 넘겨 로그인 후 원래 페이지 복귀 가능하게 구성.
UI 오버랩
카드 하트가 제목을 가리는 문제 → 목록 카드에서는 북마크 UI를 제거하고 상세에서만 제공하도록 요구에 맞춰 정리.

## 구현 이미지
- 